### PR TITLE
Add logs

### DIFF
--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -131,6 +131,7 @@ library
                  , GHC.Plugin.OllamaHoles.Backend.Ollama
                  , GHC.Plugin.OllamaHoles.Backend.OpenAI
                  , GHC.Plugin.OllamaHoles.Backend.Gemini
+                 , GHC.Plugin.OllamaHoles.Logger
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
@@ -143,7 +144,10 @@ library
                       req ^>= 3.13,
                       modern-uri ^>= 0.3,
                       aeson ^>= 2.2,
-                      containers >= 0.6 && < 0.8
+                      containers >= 0.6 && < 0.8,
+                      random >= 1.3,
+                      directory >= 1.3.10,
+                      filepath >= 1.5.5
 
 
     -- Directories containing source files.

--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -147,7 +147,10 @@ library
                       containers >= 0.6 && < 0.8,
                       random >= 1.3,
                       directory >= 1.3.10,
-                      filepath >= 1.5.5
+                      filepath >= 1.5.5,
+                      time >= 1.14,
+                      crypton >= 1.1.2,
+                      bytestring >= 0.12.2
 
 
     -- Directories containing source files.

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -98,7 +98,7 @@ mkHoleFitPluginR
 mkHoleFitPluginR opts =
     Just $
         HoleFitPluginR
-            { hfPluginInit = newTcRef $ PluginState []
+            { hfPluginInit = hfPluginInitLLM
             , hfPluginStop = \_ -> return ()
             , hfPluginRun = \ref ->
                     HoleFitPlugin
@@ -106,6 +106,9 @@ mkHoleFitPluginR opts =
                         , fitPlugin = fitPluginLLM opts ref
                         }
             }
+
+hfPluginInitLLM :: TcM (TcRef PluginState)
+hfPluginInitLLM = newTcRef $ PluginState []
 
 pluginName :: Text
 pluginName = "Ollama Plugin"

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -90,18 +90,22 @@ data PluginState = PluginState
 plugin :: Plugin
 plugin =
     defaultPlugin
-        { holeFitPlugin = \opts ->
-            Just $
-                HoleFitPluginR
-                    { hfPluginInit = newTcRef $ PluginState []
-                    , hfPluginStop = \_ -> return ()
-                    , hfPluginRun = \ref ->
-                            HoleFitPlugin
-                                { candPlugin = \_ c -> writeTcRef ref (PluginState c) >> return c
-                                , fitPlugin = fitPluginLLM opts ref
-                                }
-                    }
+        { holeFitPlugin = mkHoleFitPluginR
         }
+
+mkHoleFitPluginR
+    :: [CommandLineOption] -> Maybe HoleFitPluginR
+mkHoleFitPluginR opts =
+    Just $
+        HoleFitPluginR
+            { hfPluginInit = newTcRef $ PluginState []
+            , hfPluginStop = \_ -> return ()
+            , hfPluginRun = \ref ->
+                    HoleFitPlugin
+                        { candPlugin = \_ c -> writeTcRef ref (PluginState c) >> return c
+                        , fitPlugin = fitPluginLLM opts ref
+                        }
+            }
 
 pluginName :: Text
 pluginName = "Ollama Plugin"

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -197,7 +197,7 @@ fitPluginLLM opts ref hole fits = do
                             liftIO $ when debug $ do T.putStrLn $ pluginName <> " Response:\n```\n" <> rsp <> "\n```"
                             verified <- filterM (verifyHoleFit debug hole) lns
                             let fits' = map (RawHoleFit . text . T.unpack) verified
-                            liftIO $ Log.writeLogEvent logger $ Log.mkLogEvent mempty mempty 0 0 0
+                            liftIO $ Log.writeLogEvent logger $ Log.mkLogEvent prompt' rsp (length lns) 0 (length verified)
                             -- Return the generated fits
                             return fits'
                         Left err -> do

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -98,92 +98,100 @@ plugin =
                     , hfPluginRun = \ref ->
                             HoleFitPlugin
                                 { candPlugin = \_ c -> writeTcRef ref (PluginState c) >> return c
-                                , fitPlugin = fitPlugin opts ref
+                                , fitPlugin = fitPluginLLM opts ref
                                 }
                     }
         }
-  where
-    pluginName = "Ollama Plugin"
-    fitPlugin opts ref hole fits = do
-        PluginState cands <- readTcRef ref
-        let flags@Flags{..} = parseFlags opts
-        dflags <- getDynFlags
-        gbl_env <- getGblEnv
-        let mod_name = moduleNameString $ moduleName $ tcg_mod gbl_env
-            imports = tcg_imports gbl_env
-        let backend = getBackend flags
-        available_models <- liftIO $ listModels backend
-        liftIO $ when debug $ T.putStrLn $ "Running " <> pluginName <> " with flags:"
-        liftIO $ when debug $ print flags
 
-        case available_models of
-            Nothing ->
-                error $ T.unpack pluginName <> ": No models available, check your configuration"
-            Just models -> do
-                unless (model_name `elem` models) $
-                    error $ T.unpack pluginName
-                            <> ": Model "
-                            <> T.unpack model_name
-                            <> " not found. "
-                            <> ( if backend_name == "ollama"
-                                    then "Use `ollama pull` to download the model, or "
-                                    else ""
-                               )
-                            <> "specify another model using "
-                            <> "`-fplugin-opt=GHC.Plugin.OllamaHoles:model=<model_name>`\n"
-                            <> "Availble models: \n"
-                            <> T.unpack (T.unlines models)
-                liftIO $ when debug $ T.putStrLn $ pluginName <> ": Hole Found"
-                let mn = "Module: " <> mod_name
-                let lc = "Location: " <> showSDoc dflags (ppr $ ctLocSpan . hole_loc <$> th_hole hole)
+pluginName :: Text
+pluginName = "Ollama Plugin"
+
+fitPluginLLM
+    :: [CommandLineOption]
+    -> TcRef PluginState
+    -> TypedHole
+    -> [HoleFit]
+    -> GHC.IOEnv (Env TcGblEnv TcLclEnv) [HoleFit]
+fitPluginLLM opts ref hole fits = do
+    PluginState cands <- readTcRef ref
+    let flags@Flags{..} = parseFlags opts
+    dflags <- getDynFlags
+    gbl_env <- getGblEnv
+    let mod_name = moduleNameString $ moduleName $ tcg_mod gbl_env
+        imports = tcg_imports gbl_env
+    let backend = getBackend flags
+    available_models <- liftIO $ listModels backend
+    liftIO $ when debug $ T.putStrLn $ "Running " <> pluginName <> " with flags:"
+    liftIO $ when debug $ print flags
+
+    case available_models of
+        Nothing ->
+            error $ T.unpack pluginName <> ": No models available, check your configuration"
+        Just models -> do
+            unless (model_name `elem` models) $
+                error $ T.unpack pluginName
+                        <> ": Model "
+                        <> T.unpack model_name
+                        <> " not found. "
+                        <> ( if backend_name == "ollama"
+                                then "Use `ollama pull` to download the model, or "
+                                else ""
+                            )
+                        <> "specify another model using "
+                        <> "`-fplugin-opt=GHC.Plugin.OllamaHoles:model=<model_name>`\n"
+                        <> "Availble models: \n"
+                        <> T.unpack (T.unlines models)
+            liftIO $ when debug $ T.putStrLn $ pluginName <> ": Hole Found"
+            let mn = "Module: " <> mod_name
+            let lc = "Location: " <> showSDoc dflags (ppr $ ctLocSpan . hole_loc <$> th_hole hole)
 #if __GLASGOW_HASKELL__ >= 912
-                let im = "Imports: " <> showSDoc dflags (ppr $ Map.keys $ imp_mods imports)
+            let im = "Imports: " <> showSDoc dflags (ppr $ Map.keys $ imp_mods imports)
 #else
-                let im = "Imports: " <> showSDoc dflags (ppr $ moduleEnvKeys $ imp_mods imports)
+            let im = "Imports: " <> showSDoc dflags (ppr $ moduleEnvKeys $ imp_mods imports)
 #endif
-                case th_hole hole of
-                    Just h -> do
-                        let hv = "Hole variable: _" <> occNameString (occName $ hole_occ h)
-                        let ht = "Hole type: " <> showSDoc dflags (ppr $ hole_ty h)
-                        let rc = "Relevant constraints: " <> showSDoc dflags (ppr $ th_relevant_cts hole)
-                        let cf = "Candidate fits: " <> showSDoc dflags (ppr fits)
-                        let scope = "Things in scope: " <> showSDoc dflags (ppr $ mapMaybe fullyQualified cands)
-                        docs <- if include_docs then getDocs cands else return ""
+            case th_hole hole of
+                Just h -> do
+                    let hv = "Hole variable: _" <> occNameString (occName $ hole_occ h)
+                    let ht = "Hole type: " <> showSDoc dflags (ppr $ hole_ty h)
+                    let rc = "Relevant constraints: " <> showSDoc dflags (ppr $ th_relevant_cts hole)
+                    let cf = "Candidate fits: " <> showSDoc dflags (ppr fits)
+                    let scope = "Things in scope: " <> showSDoc dflags (ppr $ mapMaybe fullyQualified cands)
+                    docs <- if include_docs then getDocs cands else return ""
 
-                        guide <- seekGuidance cands
-                        let prompt' =
-                                replacePlaceholders
-                                    promptTemplate
-                                    [ ("{module}", mn)
-                                    , ("{location}", lc)
-                                    , ("{imports}", im)
-                                    , ("{hole_var}", hv)
-                                    , ("{hole_type}", ht)
-                                    , ("{relevant_constraints}", rc)
-                                    , ("{candidate_fits}", cf)
-                                    , ("{numexpr}", show num_expr)
-                                    , ("{guidance}", guide)
-                                    , ("{scope}", scope)
-                                    , ("{docs}", docs)
-                                    ]
-                        liftIO $ when debug $ do T.putStrLn $ pluginName <> " Prompt:\n```\n" <> prompt' <> "\n```"
-                        res <- liftIO $ generateFits backend prompt' model_name model_options
-                        case res of
-                            Right rsp -> do
-                                let lns = (preProcess . T.lines) rsp
-                                liftIO $ when debug $ do T.putStrLn $ pluginName <> " Response:\n```\n" <> rsp <> "\n```"
-                                verified <- filterM (verifyHoleFit debug hole) lns
-                                let fits' = map (RawHoleFit . text . T.unpack) verified
-                                -- Return the generated fits
-                                return fits'
-                            Left err -> do
-                                liftIO $
-                                    when debug $
-                                        T.putStrLn $
-                                            pluginName <> " failed to generate a response.\n" <> T.pack err
-                                -- Return the original fits without modification
-                                return fits
-                    Nothing -> return fits
+                    guide <- seekGuidance cands
+                    let prompt' =
+                            replacePlaceholders
+                                promptTemplate
+                                [ ("{module}", mn)
+                                , ("{location}", lc)
+                                , ("{imports}", im)
+                                , ("{hole_var}", hv)
+                                , ("{hole_type}", ht)
+                                , ("{relevant_constraints}", rc)
+                                , ("{candidate_fits}", cf)
+                                , ("{numexpr}", show num_expr)
+                                , ("{guidance}", guide)
+                                , ("{scope}", scope)
+                                , ("{docs}", docs)
+                                ]
+                    liftIO $ when debug $ do T.putStrLn $ pluginName <> " Prompt:\n```\n" <> prompt' <> "\n```"
+                    res <- liftIO $ generateFits backend prompt' model_name model_options
+                    case res of
+                        Right rsp -> do
+                            let lns = (preProcess . T.lines) rsp
+                            liftIO $ when debug $ do T.putStrLn $ pluginName <> " Response:\n```\n" <> rsp <> "\n```"
+                            verified <- filterM (verifyHoleFit debug hole) lns
+                            let fits' = map (RawHoleFit . text . T.unpack) verified
+                            -- Return the generated fits
+                            return fits'
+                        Left err -> do
+                            liftIO $
+                                when debug $
+                                    T.putStrLn $
+                                        pluginName <> " failed to generate a response.\n" <> T.pack err
+                            -- Return the original fits without modification
+                            return fits
+                Nothing -> return fits
 
 
 -- | Parse an expression in the current context

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -138,7 +138,6 @@ fitPluginLLM opts ref hole fits = do
     available_models <- liftIO $ listModels backend
     liftIO $ when debug $ T.putStrLn $ "Running " <> pluginName <> " with flags:"
     liftIO $ when debug $ print flags
-    liftIO $ Log.writeLogEvent logger Log.mkLogEvent
 
     case available_models of
         Nothing ->
@@ -198,6 +197,7 @@ fitPluginLLM opts ref hole fits = do
                             liftIO $ when debug $ do T.putStrLn $ pluginName <> " Response:\n```\n" <> rsp <> "\n```"
                             verified <- filterM (verifyHoleFit debug hole) lns
                             let fits' = map (RawHoleFit . text . T.unpack) verified
+                            liftIO $ Log.writeLogEvent logger $ Log.mkLogEvent mempty mempty 0 0 0
                             -- Return the generated fits
                             return fits'
                         Left err -> do

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -82,6 +82,10 @@ getBackend Flags{backend_name = "gemini"} = geminiBackend
 getBackend Flags{backend_name = "openai", ..} = openAICompatibleBackend openai_base_url openai_key_name
 getBackend Flags{..} = error $ "unknown backend: " <> T.unpack backend_name
 
+data PluginState = PluginState
+  { candidates :: [HoleFitCandidate]
+  }
+
 -- | Ollama plugin for GHC
 plugin :: Plugin
 plugin =
@@ -89,11 +93,11 @@ plugin =
         { holeFitPlugin = \opts ->
             Just $
                 HoleFitPluginR
-                    { hfPluginInit = newTcRef []
+                    { hfPluginInit = newTcRef $ PluginState []
                     , hfPluginStop = \_ -> return ()
                     , hfPluginRun = \ref ->
                             HoleFitPlugin
-                                { candPlugin = \_ c -> writeTcRef ref c >> return c
+                                { candPlugin = \_ c -> writeTcRef ref (PluginState c) >> return c
                                 , fitPlugin = fitPlugin opts ref
                                 }
                     }
@@ -101,7 +105,7 @@ plugin =
   where
     pluginName = "Ollama Plugin"
     fitPlugin opts ref hole fits = do
-        cands <- readTcRef ref
+        PluginState cands <- readTcRef ref
         let flags@Flags{..} = parseFlags opts
         dflags <- getDynFlags
         gbl_env <- getGblEnv

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -53,6 +53,8 @@ import qualified GHC.Tc.Solver.Monad as GHC (zonkTcType, runTcSEarlyAbort)
 import Data.Aeson (Value)
 import qualified Data.Aeson as Aeson
 
+import qualified GHC.Plugin.OllamaHoles.Logger as Log
+
 -- | Prompt used to prompt the LLM
 promptTemplate :: Text
 promptTemplate =
@@ -84,7 +86,7 @@ getBackend Flags{..} = error $ "unknown backend: " <> T.unpack backend_name
 
 data PluginState = PluginState
   { candidates    :: [HoleFitCandidate]
-  , writeLogEvent :: LogEvent -> IO ()
+  , writeLogEvent :: Log.Logger
   }
 
 -- | Ollama plugin for GHC
@@ -110,9 +112,10 @@ mkHoleFitPluginR opts =
 
 hfPluginInitLLM :: TcM (TcRef PluginState)
 hfPluginInitLLM = do
+    logger <- liftIO Log.initLogger
     newTcRef $ PluginState
         { candidates    = []
-        , writeLogEvent = \_ -> putStrLn "XYZZY"
+        , writeLogEvent = logger
         }
 
 pluginName :: Text
@@ -125,7 +128,7 @@ fitPluginLLM
     -> [HoleFit]
     -> GHC.IOEnv (Env TcGblEnv TcLclEnv) [HoleFit]
 fitPluginLLM opts ref hole fits = do
-    PluginState cands logEvent <- readTcRef ref
+    PluginState cands logger <- readTcRef ref
     let flags@Flags{..} = parseFlags opts
     dflags <- getDynFlags
     gbl_env <- getGblEnv
@@ -135,7 +138,7 @@ fitPluginLLM opts ref hole fits = do
     available_models <- liftIO $ listModels backend
     liftIO $ when debug $ T.putStrLn $ "Running " <> pluginName <> " with flags:"
     liftIO $ when debug $ print flags
-    liftIO $ logEvent LogEvent
+    liftIO $ Log.writeLogEvent logger Log.mkLogEvent
 
     case available_models of
         Nothing ->
@@ -400,5 +403,3 @@ replacePlaceholders = foldl replacePlaceholder
   where
     replacePlaceholder :: Text -> (Text, String) -> Text
     replacePlaceholder str (placeholder, value) = T.replace placeholder (T.pack value) str
-
-data LogEvent = LogEvent

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -13,7 +13,7 @@ import Data.Text.IO qualified as T
 import GHC.Plugins hiding ((<>))
 import GHC.Tc.Types
 import GHC.Tc.Types.Constraint (Hole (..))
-import GHC.Tc.Utils.Monad (getGblEnv, newTcRef, writeTcRef, readTcRef, discardErrs, ifErrsM)
+import GHC.Tc.Utils.Monad (getGblEnv, newTcRef, writeTcRef, readTcRef, updTcRef, discardErrs, ifErrsM)
 import qualified GHC.Tc.Utils.Monad as GHC
 
 import GHC.Plugin.OllamaHoles.Backend
@@ -83,7 +83,8 @@ getBackend Flags{backend_name = "openai", ..} = openAICompatibleBackend openai_b
 getBackend Flags{..} = error $ "unknown backend: " <> T.unpack backend_name
 
 data PluginState = PluginState
-  { candidates :: [HoleFitCandidate]
+  { candidates    :: [HoleFitCandidate]
+  , writeLogEvent :: LogEvent -> IO ()
   }
 
 -- | Ollama plugin for GHC
@@ -102,13 +103,17 @@ mkHoleFitPluginR opts =
             , hfPluginStop = \_ -> return ()
             , hfPluginRun = \ref ->
                     HoleFitPlugin
-                        { candPlugin = \_ c -> writeTcRef ref (PluginState c) >> return c
+                        { candPlugin = \_ c -> updTcRef ref (\st -> st { candidates = c }) >> return c
                         , fitPlugin = fitPluginLLM opts ref
                         }
             }
 
 hfPluginInitLLM :: TcM (TcRef PluginState)
-hfPluginInitLLM = newTcRef $ PluginState []
+hfPluginInitLLM = do
+    newTcRef $ PluginState
+        { candidates    = []
+        , writeLogEvent = \_ -> putStrLn "XYZZY"
+        }
 
 pluginName :: Text
 pluginName = "Ollama Plugin"
@@ -120,7 +125,7 @@ fitPluginLLM
     -> [HoleFit]
     -> GHC.IOEnv (Env TcGblEnv TcLclEnv) [HoleFit]
 fitPluginLLM opts ref hole fits = do
-    PluginState cands <- readTcRef ref
+    PluginState cands logEvent <- readTcRef ref
     let flags@Flags{..} = parseFlags opts
     dflags <- getDynFlags
     gbl_env <- getGblEnv
@@ -130,6 +135,7 @@ fitPluginLLM opts ref hole fits = do
     available_models <- liftIO $ listModels backend
     liftIO $ when debug $ T.putStrLn $ "Running " <> pluginName <> " with flags:"
     liftIO $ when debug $ print flags
+    liftIO $ logEvent LogEvent
 
     case available_models of
         Nothing ->
@@ -394,3 +400,5 @@ replacePlaceholders = foldl replacePlaceholder
   where
     replacePlaceholder :: Text -> (Text, String) -> Text
     replacePlaceholder str (placeholder, value) = T.replace placeholder (T.pack value) str
+
+data LogEvent = LogEvent

--- a/src/GHC/Plugin/OllamaHoles/Logger.hs
+++ b/src/GHC/Plugin/OllamaHoles/Logger.hs
@@ -13,6 +13,13 @@ import qualified Data.Text as T
 import           Data.Word (Word32)
 import           GHC.Generics (Generic)
 import           Numeric (showHex)
+import           System.Directory
+    ( XdgDirectory(XdgState)
+    , createDirectoryIfMissing
+    , doesFileExist
+    , getXdgDirectory
+    )
+import           System.FilePath ((</>))
 import           System.Random (randomIO)
 
 
@@ -44,14 +51,45 @@ writeLogEvent logger event = do
 
 data LogConfig = LogConfig
     { sessionId :: SessionId
+    , logPaths  :: LogPaths
     } deriving (Eq, Show, Generic)
 
 initLogConfig :: IO LogConfig
 initLogConfig = do
     sId <- genSessionId
+    paths <- mkDefaultLogPaths Nothing
     pure $ LogConfig
         { sessionId = sId
         }
+
+data LogPaths = LogPaths
+    { lpRootDir   :: FilePath -- e.g. ~/.local/state/ollama-holes
+    , lpEventsDir :: FilePath -- e.g. ~/.local/state/ollama-holes/events
+    , lpBlobDir   :: FilePath -- e.g. ~/.local/state/ollama-holes/blob
+    } deriving (Eq, Show, Generic)
+
+-- | Get the default location for storing logs
+mkDefaultLogPaths
+    :: Maybe FilePath -- Optional root directory
+    -> IO LogPaths
+mkDefaultLogPaths mRoot = do
+    root <- case mRoot of
+        Just fp -> pure fp
+        Nothing -> getXdgDirectory XdgState "ollama-holes"
+    let paths = LogPaths
+          { lpRootDir   = root
+          , lpEventsDir = root </> "events"
+          , lpBlobDir   = root </> "blob"
+          }
+    ensureLogDirs paths
+    pure paths
+
+-- | Create any log directories that don't exist.
+ensureLogDirs :: LogPaths -> IO ()
+ensureLogDirs paths = do
+    createDirectoryIfMissing True $ lpRootDir paths
+    createDirectoryIfMissing True $ lpEventsDir paths
+    createDirectoryIfMissing True $ lpBlobDir paths
 
 
 

--- a/src/GHC/Plugin/OllamaHoles/Logger.hs
+++ b/src/GHC/Plugin/OllamaHoles/Logger.hs
@@ -1,0 +1,34 @@
+module GHC.Plugin.OllamaHoles.Logger
+    ( Logger()
+    , initLogger
+    , writeLogEvent
+    , LogEvent()
+    , mkLogEvent
+    ) where
+
+
+
+-- | Opaque logging object
+data Logger = Logger
+    { logEvent :: LogEvent -> IO ()
+    }
+
+-- | Initialize a logger
+initLogger :: IO Logger
+initLogger = pure $ Logger
+    { logEvent = \_ -> putStrLn "XYZZY"
+    }
+
+-- | Invoke a logger
+writeLogEvent :: Logger -> LogEvent -> IO ()
+writeLogEvent logger event = do
+    let Logger write = logger
+    write event
+
+
+
+data LogEvent = LogEvent
+
+-- | Smart constructor
+mkLogEvent :: LogEvent
+mkLogEvent = LogEvent

--- a/src/GHC/Plugin/OllamaHoles/Logger.hs
+++ b/src/GHC/Plugin/OllamaHoles/Logger.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module GHC.Plugin.OllamaHoles.Logger
     ( Logger()
     , initLogger
@@ -9,7 +11,18 @@ module GHC.Plugin.OllamaHoles.Logger
 
 
 
+import qualified Crypto.Hash as H
+import           Data.Aeson (encode, FromJSON(..), ToJSON(..), (.:))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as T
+import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Encoding as TE
+import           Data.Time.Clock (getCurrentTime)
+import           Data.Time.Format (defaultTimeLocale, formatTime)
 import           Data.Word (Word32)
 import           GHC.Generics (Generic)
 import           Numeric (showHex)
@@ -35,11 +48,34 @@ initLogger :: IO Logger
 initLogger = do
     logConfig <- initLogConfig
     pure $ Logger
-      { logEvent = \_ -> putStrLn "XYZZY"
-      , config   = logConfig
-      }
+        { logEvent = recordLogEvent logConfig
+        , config   = logConfig
+        }
 
--- | Invoke a logger
+recordLogEvent :: LogConfig -> LogEvent -> IO ()
+recordLogEvent config event = do
+    now <- getFormattedTimestamp
+    let record = renderLogEvent now config event
+    putStrLn "XYZZY"
+
+renderLogEvent
+    :: Timestamp -> LogConfig -> LogEvent
+    -> (LBS.ByteString, PromptHash, ResponseHash)
+renderLogEvent now config event =
+    let promptHash = contentHash $ lePrompt event
+        responseHash = contentHash $ leResponse event
+        line = encode $ Aeson.Object $ KM.fromList
+            [ (Key.fromText "timestamp"        , toJSON now)
+            , (Key.fromText "session_id"       , toJSON $ unSessionId $ sessionId config)
+            , (Key.fromText "suggestion_count" , toJSON $ leSuggestionCount event)
+            , (Key.fromText "unique_count"     , toJSON $ leUniqueCount event)
+            , (Key.fromText "valid_count"      , toJSON $ leValidCount event)
+            , (Key.fromText "prompt_hash"      , toJSON promptHash)
+            , (Key.fromText "response_hash"    , toJSON responseHash)
+            ]
+    in (line, promptHash, responseHash)
+
+-- | Invoke a logger (this is exposed)
 writeLogEvent :: Logger -> LogEvent -> IO ()
 writeLogEvent logger event = do
     let Logger write config = logger
@@ -91,21 +127,45 @@ ensureLogDirs paths = do
     createDirectoryIfMissing True $ lpEventsDir paths
     createDirectoryIfMissing True $ lpBlobDir paths
 
+getFormattedTimestamp :: IO Timestamp
+getFormattedTimestamp = do
+  now <- getCurrentTime
+  pure . T.pack $ formatTime defaultTimeLocale "%Y-%m-%d_%H:%M:%S" now
+
+contentHash :: T.Text -> T.Text
+contentHash =
+  T.pack . show . (H.hash . TE.encodeUtf8 :: T.Text -> H.Digest H.SHA256)
+
 
 
 -- Events
 
 data LogEvent = LogEvent
+  { lePrompt          :: Prompt
+  , leResponse        :: Response
+  , leSuggestionCount :: SuggestionCount -- returned by the LLM
+  , leUniqueCount     :: UniqueCount     -- deduplicated (llm may be redundant)
+  , leValidCount      :: ValidCount      -- how many unique candidates where valid
+  }
+
+type Prompt          = T.Text
+type Response        = T.Text
+type SuggestionCount = Int
+type UniqueCount     = Int
+type ValidCount      = Int
+type Timestamp       = T.Text
+type PromptHash      = T.Text
+type ResponseHash    = T.Text
 
 -- | Smart constructor
 mkLogEvent :: LogEvent
-mkLogEvent = LogEvent
+mkLogEvent = LogEvent mempty mempty 0 0 0
 
 
 
 -- Helpers
 
-newtype SessionId = SessionId T.Text
+newtype SessionId = SessionId { unSessionId :: T.Text }
   deriving (Eq, Ord, Show, Generic)
 
 genSessionId :: IO SessionId

--- a/src/GHC/Plugin/OllamaHoles/Logger.hs
+++ b/src/GHC/Plugin/OllamaHoles/Logger.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 module GHC.Plugin.OllamaHoles.Logger
     ( Logger()
     , initLogger
@@ -8,27 +9,70 @@ module GHC.Plugin.OllamaHoles.Logger
 
 
 
+import qualified Data.Text as T
+import           Data.Word (Word32)
+import           GHC.Generics (Generic)
+import           Numeric (showHex)
+import           System.Random (randomIO)
+
+
+
 -- | Opaque logging object
 data Logger = Logger
     { logEvent :: LogEvent -> IO ()
+    , config   :: LogConfig
     }
 
 -- | Initialize a logger
 initLogger :: IO Logger
-initLogger = pure $ Logger
-    { logEvent = \_ -> putStrLn "XYZZY"
-    }
+initLogger = do
+    logConfig <- initLogConfig
+    pure $ Logger
+      { logEvent = \_ -> putStrLn "XYZZY"
+      , config   = logConfig
+      }
 
 -- | Invoke a logger
 writeLogEvent :: Logger -> LogEvent -> IO ()
 writeLogEvent logger event = do
-    let Logger write = logger
+    let Logger write config = logger
     write event
 
 
+
+-- Configuration
+
+data LogConfig = LogConfig
+    { sessionId :: SessionId
+    } deriving (Eq, Show, Generic)
+
+initLogConfig :: IO LogConfig
+initLogConfig = do
+    sId <- genSessionId
+    pure $ LogConfig
+        { sessionId = sId
+        }
+
+
+
+-- Events
 
 data LogEvent = LogEvent
 
 -- | Smart constructor
 mkLogEvent :: LogEvent
 mkLogEvent = LogEvent
+
+
+
+-- Helpers
+
+newtype SessionId = SessionId T.Text
+  deriving (Eq, Ord, Show, Generic)
+
+genSessionId :: IO SessionId
+genSessionId = do
+  w <- randomIO :: IO Word32
+  -- Note: showHex is a ShowS, which prepends the (hex
+  -- representation of) the left argument onto the right.
+  pure $ SessionId $ T.pack $ take 8 $ showHex w "00000000"

--- a/src/GHC/Plugin/OllamaHoles/Logger.hs
+++ b/src/GHC/Plugin/OllamaHoles/Logger.hs
@@ -11,9 +11,11 @@ module GHC.Plugin.OllamaHoles.Logger
 
 
 
+import           Control.Monad (unless)
 import qualified Crypto.Hash as H
-import           Data.Aeson (encode, FromJSON(..), ToJSON(..), (.:))
+import           Data.Aeson (encode, FromJSON(..), ToJSON(..), (.:), (.=))
 import qualified Data.Aeson as Aeson
+import           Data.Aeson.Encoding (pairs, encodingToLazyByteString)
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.ByteString as BS
@@ -32,7 +34,7 @@ import           System.Directory
     , doesFileExist
     , getXdgDirectory
     )
-import           System.FilePath ((</>))
+import           System.FilePath ((</>), dropTrailingPathSeparator, takeDirectory)
 import           System.Random (randomIO)
 
 
@@ -55,8 +57,19 @@ initLogger = do
 recordLogEvent :: LogConfig -> LogEvent -> IO ()
 recordLogEvent config event = do
     now <- getFormattedTimestamp
-    let record = renderLogEvent now config event
-    putStrLn "XYZZY"
+    let (record, promptHash, responseHash) = renderLogEvent now config event
+    case logMode config of
+        LogOff ->
+            pure ()
+
+        LogBasic -> do
+            appendEventLine config record
+
+        LogFull -> do
+            appendEventLine config record
+            _ <- writeBlobIfAbsent config BlobPrompt   (BlobHash promptHash)   (lePrompt event)
+            _ <- writeBlobIfAbsent config BlobResponse (BlobHash responseHash) (leResponse event)
+            pure ()
 
 renderLogEvent
     :: Timestamp -> LogConfig -> LogEvent
@@ -64,15 +77,20 @@ renderLogEvent
 renderLogEvent now config event =
     let promptHash = contentHash $ lePrompt event
         responseHash = contentHash $ leResponse event
-        line = encode $ Aeson.Object $ KM.fromList
-            [ (Key.fromText "timestamp"        , toJSON now)
-            , (Key.fromText "session_id"       , toJSON $ unSessionId $ sessionId config)
-            , (Key.fromText "suggestion_count" , toJSON $ leSuggestionCount event)
-            , (Key.fromText "unique_count"     , toJSON $ leUniqueCount event)
-            , (Key.fromText "valid_count"      , toJSON $ leValidCount event)
-            , (Key.fromText "prompt_hash"      , toJSON promptHash)
-            , (Key.fromText "response_hash"    , toJSON responseHash)
-            ]
+
+        enc :: Aeson.Encoding
+        enc =
+            -- Manually encoding so we have control over key order
+            pairs $
+                "timestamp"           .= now
+                <> "session_id"       .= unSessionId (sessionId config)
+                <> "suggestion_count" .= leSuggestionCount event
+                <> "unique_count"     .= leUniqueCount event
+                <> "valid_count"      .= leValidCount event
+                <> "prompt_hash"      .= promptHash
+                <> "response_hash"    .= responseHash
+
+        line = encodingToLazyByteString enc
     in (line, promptHash, responseHash)
 
 -- | Invoke a logger (this is exposed)
@@ -88,7 +106,14 @@ writeLogEvent logger event = do
 data LogConfig = LogConfig
     { sessionId :: SessionId
     , logPaths  :: LogPaths
+    , logMode   :: LogMode
     } deriving (Eq, Show, Generic)
+
+data LogMode
+  = LogOff
+  | LogBasic -- JSONL events only
+  | LogFull  -- JSONL events + prompt/response blobs
+  deriving (Eq, Show, Generic)
 
 initLogConfig :: IO LogConfig
 initLogConfig = do
@@ -96,11 +121,12 @@ initLogConfig = do
     paths <- mkDefaultLogPaths Nothing
     pure $ LogConfig
         { sessionId = sId
+        , logPaths  = paths
+        , logMode   = LogFull
         }
 
 data LogPaths = LogPaths
     { lpRootDir   :: FilePath -- e.g. ~/.local/state/ollama-holes
-    , lpEventsDir :: FilePath -- e.g. ~/.local/state/ollama-holes/events
     , lpBlobDir   :: FilePath -- e.g. ~/.local/state/ollama-holes/blob
     } deriving (Eq, Show, Generic)
 
@@ -114,7 +140,6 @@ mkDefaultLogPaths mRoot = do
         Nothing -> getXdgDirectory XdgState "ollama-holes"
     let paths = LogPaths
           { lpRootDir   = root
-          , lpEventsDir = root </> "events"
           , lpBlobDir   = root </> "blob"
           }
     ensureLogDirs paths
@@ -124,7 +149,6 @@ mkDefaultLogPaths mRoot = do
 ensureLogDirs :: LogPaths -> IO ()
 ensureLogDirs paths = do
     createDirectoryIfMissing True $ lpRootDir paths
-    createDirectoryIfMissing True $ lpEventsDir paths
     createDirectoryIfMissing True $ lpBlobDir paths
 
 getFormattedTimestamp :: IO Timestamp
@@ -141,12 +165,12 @@ contentHash =
 -- Events
 
 data LogEvent = LogEvent
-  { lePrompt          :: Prompt
-  , leResponse        :: Response
-  , leSuggestionCount :: SuggestionCount -- returned by the LLM
-  , leUniqueCount     :: UniqueCount     -- deduplicated (llm may be redundant)
-  , leValidCount      :: ValidCount      -- how many unique candidates where valid
-  }
+    { lePrompt          :: Prompt
+    , leResponse        :: Response
+    , leSuggestionCount :: SuggestionCount -- returned by the LLM
+    , leUniqueCount     :: UniqueCount     -- deduplicated (llm may be redundant)
+    , leValidCount      :: ValidCount      -- how many unique candidates where valid
+    }
 
 type Prompt          = T.Text
 type Response        = T.Text
@@ -156,10 +180,14 @@ type ValidCount      = Int
 type Timestamp       = T.Text
 type PromptHash      = T.Text
 type ResponseHash    = T.Text
+type Blob            = T.Text
 
 -- | Smart constructor
-mkLogEvent :: LogEvent
-mkLogEvent = LogEvent mempty mempty 0 0 0
+mkLogEvent
+    :: Prompt -> Response
+    -> SuggestionCount -> UniqueCount -> ValidCount
+    -> LogEvent
+mkLogEvent = LogEvent
 
 
 
@@ -174,3 +202,49 @@ genSessionId = do
   -- Note: showHex is a ShowS, which prepends the (hex
   -- representation of) the left argument onto the right.
   pure $ SessionId $ T.pack $ take 8 $ showHex w "00000000"
+
+
+
+-- Blobs
+
+data BlobKind
+    = BlobPrompt
+    | BlobResponse
+    deriving (Eq, Ord, Show, Generic)
+
+data BlobHash = BlobHash
+    { unBlobHash :: T.Text
+    } deriving (Eq, Ord, Show, Generic)
+
+mkBlobPath :: LogPaths -> BlobKind -> BlobHash -> FilePath
+mkBlobPath LogPaths{lpBlobDir} kind (BlobHash h) =
+  let bucket = case kind of
+          BlobPrompt   -> "prompt"
+          BlobResponse -> "response"
+
+      hs = T.unpack h
+      shard = case hs of
+          a:b:_ -> [a,b]
+          _     -> "00"
+  in dropTrailingPathSeparator lpBlobDir </> bucket </> shard </> hs
+
+writeBlobIfAbsent
+  :: LogConfig -> BlobKind -> BlobHash -> T.Text -> IO FilePath
+writeBlobIfAbsent config kind h txt = do
+  let fp = mkBlobPath (logPaths config) kind h
+  createDirectoryIfMissing True (takeDirectory fp)
+  exists <- doesFileExist fp
+  unless exists $ BS.writeFile fp (TE.encodeUtf8 txt)
+  pure fp
+
+appendEventLine
+  :: LogConfig -> LBS.ByteString -> IO ()
+appendEventLine config line = do
+  let fp = eventsFileForSession (logPaths config)
+  createDirectoryIfMissing True (takeDirectory fp)
+  LBS.appendFile fp (line <> "\n")
+
+eventsFileForSession :: LogPaths -> FilePath
+eventsFileForSession paths =
+    let dir = lpRootDir paths
+    in dropTrailingPathSeparator dir </> "hole-fit-logs.jsonl"


### PR DESCRIPTION
Address #1.

Adds the ability to write logs when the plugin runs. To start we're storing the prompt, the response, some stats (number of candidates, number of "distinct" candidates, number of valid candidates), a session ID, and a timestamp.

The main goal of storing stats is to try to quantify the quality of the output. Those metrics are not perfect but they are good enough to start.

I recommend reading the commits in order.