### PR TITLE
Add prompt templating

### DIFF
--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -195,6 +195,9 @@ test-suite ollama-holes-spec
     , GHC.Plugin.OllamaHoles.Candidate.Compat.Spec
     , GHC.Plugin.OllamaHoles.Candidate.Normalize.Spec
     , GHC.Plugin.OllamaHoles.Candidate.Rewrite.Spec
+    , GHC.Plugin.OllamaHoles.Candidate.WithRenamedExpr
+    , GHC.Plugin.OllamaHoles.Template.Load.Spec
+    , GHC.Plugin.OllamaHoles.Template.Parse.Spec
   build-depends:
       base
     , ollama-holes-plugin

--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -125,6 +125,7 @@ library
 
     -- Modules exported by the library.
     exposed-modules:  GHC.Plugin.OllamaHoles
+                    , GHC.Plugin.OllamaHoles.Template
 
     -- Modules included in this library but not exported.
     other-modules: GHC.Plugin.OllamaHoles.Backend
@@ -136,7 +137,6 @@ library
                  , GHC.Plugin.OllamaHoles.Candidate
                  , GHC.Plugin.OllamaHoles.Candidate.Compat
                  , GHC.Plugin.OllamaHoles.Candidate.Rewrite
-                 , GHC.Plugin.OllamaHoles.Template
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
@@ -173,7 +173,7 @@ library ollama-holes-lib
       GHC.Plugin.OllamaHoles.Candidate
     , GHC.Plugin.OllamaHoles.Candidate.Compat
     , GHC.Plugin.OllamaHoles.Candidate.Rewrite
-    , GHC.Plugin.OllamaHoles.Template
+    --, GHC.Plugin.OllamaHoles.Template
   default-language:    GHC2021
   build-depends:
       base
@@ -198,6 +198,7 @@ test-suite ollama-holes-spec
     , GHC.Plugin.OllamaHoles.Candidate.WithRenamedExpr
     , GHC.Plugin.OllamaHoles.Template.Load.Spec
     , GHC.Plugin.OllamaHoles.Template.Parse.Spec
+    , GHC.Plugin.OllamaHoles.Options.Spec
   build-depends:
       base
     , ollama-holes-plugin

--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -136,6 +136,7 @@ library
                  , GHC.Plugin.OllamaHoles.Candidate
                  , GHC.Plugin.OllamaHoles.Candidate.Compat
                  , GHC.Plugin.OllamaHoles.Candidate.Rewrite
+                 , GHC.Plugin.OllamaHoles.Template
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
@@ -154,7 +155,8 @@ library
                       filepath >= 1.5.5,
                       time >= 1.14,
                       crypton >= 1.1.2,
-                      bytestring >= 0.12.2
+                      bytestring >= 0.12.2,
+                      directory >= 1.3.10.1
 
     -- Directories containing source files.
     hs-source-dirs:   src
@@ -171,12 +173,15 @@ library ollama-holes-lib
       GHC.Plugin.OllamaHoles.Candidate
     , GHC.Plugin.OllamaHoles.Candidate.Compat
     , GHC.Plugin.OllamaHoles.Candidate.Rewrite
+    , GHC.Plugin.OllamaHoles.Template
   default-language:    GHC2021
   build-depends:
       base
     , ghc
     , containers
     , text
+    , directory
+    , filepath
 
 
 

--- a/spec/GHC/Plugin/OllamaHoles/Options/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Options/Spec.hs
@@ -14,6 +14,7 @@ import GHC.Plugin.OllamaHoles
 import GHC.Plugin.OllamaHoles.Template
     ( TemplateSpec(..)
     , TemplateSource(..)
+    , TemplateError(..)
     , unsafeCreateRawTemplateName
     )
 
@@ -102,10 +103,10 @@ mkTemplateSpecTests :: TestTree
 mkTemplateSpecTests = testGroup "mkTemplateSpec"
     [ testCase "default flags choose DefaultTemplate" $ do
         mkTemplateSpec defaultFlags
-            @?= TemplateSpec
+            @?= Right (TemplateSpec
                 { tsSearchDir = "."
                 , tsSource = DefaultTemplate
-                }
+                })
 
     , testCase "path chooses TemplateFile" $ do
         let flags = defaultFlags
@@ -114,10 +115,10 @@ mkTemplateSpecTests = testGroup "mkTemplateSpec"
               , template_search_dir = "/tmp/templates"
               }
         mkTemplateSpec flags
-            @?= TemplateSpec
+            @?= Right (TemplateSpec
                 { tsSearchDir = "/tmp/templates"
                 , tsSource = TemplateFile "/tmp/prompt.txt"
-                }
+                })
 
     , testCase "name chooses NamedTemplate" $ do
         let flags = defaultFlags
@@ -126,19 +127,19 @@ mkTemplateSpecTests = testGroup "mkTemplateSpec"
               , template_search_dir = "/tmp/templates"
               }
         mkTemplateSpec flags
-            @?= TemplateSpec
+            @?= Right (TemplateSpec
                 { tsSearchDir = "/tmp/templates"
                 , tsSource = NamedTemplate $ unsafeCreateRawTemplateName "qwen"
-                }
+                })
 
     , testCase "search dir is preserved with default template" $ do
         let flags = defaultFlags
               { template_search_dir = "/tmp/templates" }
         mkTemplateSpec flags
-            @?= TemplateSpec
+            @?= Right (TemplateSpec
                 { tsSearchDir = "/tmp/templates"
                 , tsSource = DefaultTemplate
-                }
+                })
 
     , testCase "path beats name in mkTemplateSpec if both are present" $ do
         let flags = defaultFlags
@@ -147,8 +148,17 @@ mkTemplateSpecTests = testGroup "mkTemplateSpec"
               , template_search_dir = "/tmp/templates"
               }
         mkTemplateSpec flags
-            @?= TemplateSpec
+            @?= Right (TemplateSpec
                 { tsSearchDir = "/tmp/templates"
                 , tsSource = TemplateFile "/tmp/prompt.txt"
-                }
+                })
+
+    , testCase "invalid name is rejected" $ do
+        let flags = defaultFlags
+              { template_path = Nothing
+              , template_name = Just "../secrets"
+              , template_search_dir = "/tmp/templates"
+              }
+        mkTemplateSpec flags
+            @?= Left (InvalidTemplateName "../secrets")
     ]

--- a/spec/GHC/Plugin/OllamaHoles/Options/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Options/Spec.hs
@@ -1,0 +1,153 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module GHC.Plugin.OllamaHoles.Options.Spec (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import GHC.Plugin.OllamaHoles
+    ( Flags(..)
+    , defaultFlags
+    , parseFlags
+    , mkTemplateSpec
+    )
+import GHC.Plugin.OllamaHoles.Template
+    ( TemplateSpec(..)
+    , TemplateSource(..)
+    )
+
+tests :: TestTree
+tests = testGroup "template-related option parsing"
+    [ parseFlagsTests
+    , mkTemplateSpecTests
+    ]
+
+parseFlagsTests :: TestTree
+parseFlagsTests = testGroup "parseFlags"
+    [ testCase "defaults contain no template path or name" $ do
+        let flags = parseFlags []
+        template_path flags @?= Nothing
+        template_name flags @?= Nothing
+        template_search_dir flags @?= "."
+
+    , testCase "template= sets path and clears name" $ do
+        let flags = parseFlags ["template=/tmp/prompt.txt"]
+        template_path flags @?= Just "/tmp/prompt.txt"
+        template_name flags @?= Nothing
+
+    , testCase "template-name= sets name and clears path" $ do
+        let flags = parseFlags ["template-name=qwen"]
+        template_path flags @?= Nothing
+        template_name flags @?= Just "qwen"
+
+    , testCase "template-dir= sets search dir" $ do
+        let flags = parseFlags ["template-dir=/tmp/templates"]
+        template_search_dir flags @?= "/tmp/templates"
+
+    , testCase "leftmost template selector wins: path then name keeps path" $ do
+        let flags = parseFlags
+              [ "template=/tmp/a.txt"
+              , "template-name=qwen"
+              ]
+        template_path flags @?= Just "/tmp/a.txt"
+        template_name flags @?= Nothing
+
+    , testCase "leftmost template selector wins: name then path keeps name" $ do
+        let flags = parseFlags
+              [ "template-name=qwen"
+              , "template=/tmp/a.txt"
+              ]
+        template_path flags @?= Nothing
+        template_name flags @?= Just "qwen"
+
+    , testCase "leftmost template-dir wins" $ do
+        let flags = parseFlags
+              [ "template-dir=/tmp/one"
+              , "template-dir=/tmp/two"
+              ]
+        template_search_dir flags @?= "/tmp/one"
+
+    , testCase "template-dir combines with template-name" $ do
+        let flags = parseFlags
+              [ "template-dir=/tmp/templates"
+              , "template-name=qwen"
+              ]
+        template_search_dir flags @?= "/tmp/templates"
+        template_name flags @?= Just "qwen"
+        template_path flags @?= Nothing
+
+    , testCase "template-dir combines with template path" $ do
+        let flags = parseFlags
+              [ "template-dir=/tmp/templates"
+              , "template=/tmp/prompt.txt"
+              ]
+        template_search_dir flags @?= "/tmp/templates"
+        template_path flags @?= Just "/tmp/prompt.txt"
+        template_name flags @?= Nothing
+
+    , testCase "leftmost template selector still wins when interleaved with dir flags" $ do
+        let flags = parseFlags
+              [ "template-name=alpha"
+              , "template-dir=/tmp/one"
+              , "template=/tmp/prompt.txt"
+              , "template-dir=/tmp/two"
+              ]
+        template_name flags @?= Just "alpha"
+        template_path flags @?= Nothing
+        template_search_dir flags @?= "/tmp/one"
+    ]
+
+mkTemplateSpecTests :: TestTree
+mkTemplateSpecTests = testGroup "mkTemplateSpec"
+    [ testCase "default flags choose DefaultTemplate" $ do
+        mkTemplateSpec defaultFlags
+            @?= TemplateSpec
+                { tsSearchDir = "."
+                , tsSource = DefaultTemplate
+                }
+
+    , testCase "path chooses TemplateFile" $ do
+        let flags = defaultFlags
+              { template_path = Just "/tmp/prompt.txt"
+              , template_name = Nothing
+              , template_search_dir = "/tmp/templates"
+              }
+        mkTemplateSpec flags
+            @?= TemplateSpec
+                { tsSearchDir = "/tmp/templates"
+                , tsSource = TemplateFile "/tmp/prompt.txt"
+                }
+
+    , testCase "name chooses NamedTemplate" $ do
+        let flags = defaultFlags
+              { template_path = Nothing
+              , template_name = Just "qwen"
+              , template_search_dir = "/tmp/templates"
+              }
+        mkTemplateSpec flags
+            @?= TemplateSpec
+                { tsSearchDir = "/tmp/templates"
+                , tsSource = NamedTemplate "qwen"
+                }
+
+    , testCase "search dir is preserved with default template" $ do
+        let flags = defaultFlags
+              { template_search_dir = "/tmp/templates" }
+        mkTemplateSpec flags
+            @?= TemplateSpec
+                { tsSearchDir = "/tmp/templates"
+                , tsSource = DefaultTemplate
+                }
+
+    , testCase "path beats name in mkTemplateSpec if both are present" $ do
+        let flags = defaultFlags
+              { template_path = Just "/tmp/prompt.txt"
+              , template_name = Just "qwen"
+              , template_search_dir = "/tmp/templates"
+              }
+        mkTemplateSpec flags
+            @?= TemplateSpec
+                { tsSearchDir = "/tmp/templates"
+                , tsSource = TemplateFile "/tmp/prompt.txt"
+                }
+    ]

--- a/spec/GHC/Plugin/OllamaHoles/Options/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Options/Spec.hs
@@ -14,6 +14,7 @@ import GHC.Plugin.OllamaHoles
 import GHC.Plugin.OllamaHoles.Template
     ( TemplateSpec(..)
     , TemplateSource(..)
+    , unsafeCreateRawTemplateName
     )
 
 tests :: TestTree
@@ -127,7 +128,7 @@ mkTemplateSpecTests = testGroup "mkTemplateSpec"
         mkTemplateSpec flags
             @?= TemplateSpec
                 { tsSearchDir = "/tmp/templates"
-                , tsSource = NamedTemplate "qwen"
+                , tsSource = NamedTemplate $ unsafeCreateRawTemplateName "qwen"
                 }
 
     , testCase "search dir is preserved with default template" $ do

--- a/spec/GHC/Plugin/OllamaHoles/Template/Expand/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Template/Expand/Spec.hs
@@ -1,0 +1,175 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module GHC.Plugin.OllamaHoles.Template.Expand.Spec (tests) where
+
+import Data.Text qualified as T
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import GHC.Plugin.OllamaHoles.Template
+  ( Template(..)
+  , TemplateExpr(..)
+  , Placeholder(..)
+  , TemplateSpec(..)
+  , TemplateSource(..)
+  , TemplateError(..)
+  , mkTemplateEnv
+  , loadTemplate
+  , expandTemplate
+  )
+
+tests :: TestTree
+tests =
+  testGroup "Template expansion"
+    [ basicExpansionTests
+    , failureExpansionTests
+    , defaultTemplateTests
+    ]
+
+basicExpansionTests :: TestTree
+basicExpansionTests =
+  testGroup "basic expansion"
+    [ testCase "chunks-only template expands unchanged" $ do
+        let env  = mkTemplateEnv []
+            tmpl = Template [TemplateChunk "hello world"]
+        expandTemplate env tmpl
+          @?= Right "hello world"
+
+    , testCase "single placeholder expands" $ do
+        let env  = mkTemplateEnv [("name", "Nathan")]
+            tmpl = Template [TemplateChunk "hello ", TemplateVar "name", TemplateChunk "!"]
+        expandTemplate env tmpl
+          @?= Right "hello Nathan!"
+
+    , testCase "adjacent placeholders expand in order" $ do
+        let env =
+              mkTemplateEnv
+                [ ("x", "A")
+                , ("y", "B")
+                ]
+            tmpl =
+              Template
+                [ TemplateVar "x"
+                , TemplateVar "y"
+                ]
+        expandTemplate env tmpl
+          @?= Right "AB"
+
+    , testCase "mixed chunks and placeholders expand correctly" $ do
+        let env =
+              mkTemplateEnv
+                [ ("greeting", "hello")
+                , ("name", "world")
+                ]
+            tmpl =
+              Template
+                [ TemplateVar "greeting"
+                , TemplateChunk ", "
+                , TemplateVar "name"
+                , TemplateChunk "!"
+                ]
+        expandTemplate env tmpl
+          @?= Right "hello, world!"
+
+    , testCase "unused environment entries are ignored" $ do
+        let env =
+              mkTemplateEnv
+                [ ("used", "ok")
+                , ("unused", "ignored")
+                ]
+            tmpl =
+              Template
+                [ TemplateChunk "value="
+                , TemplateVar "used"
+                ]
+        expandTemplate env tmpl
+          @?= Right "value=ok"
+    ]
+
+failureExpansionTests :: TestTree
+failureExpansionTests =
+  testGroup "expansion failures"
+    [ testCase "unknown placeholder is reported" $ do
+        let env  = mkTemplateEnv [("context", "ctx")]
+            tmpl = Template [TemplateChunk "x=", TemplateVar "missing"]
+        expandTemplate env tmpl
+          @?= Left (UnknownPlaceholders ["missing"])
+
+    , testCase "repeated unknown placeholders are reported in occurrence order" $ do
+        let env = mkTemplateEnv []
+            tmpl =
+              Template
+                [ TemplateVar "missing"
+                , TemplateChunk "-"
+                , TemplateVar "missing"
+                ]
+        expandTemplate env tmpl
+          @?= Left (UnknownPlaceholders ["missing", "missing"])
+
+    , testCase "mixed known and unknown placeholders reports only unknown ones" $ do
+        let env =
+              mkTemplateEnv
+                [ ("known", "ok") ]
+            tmpl =
+              Template
+                [ TemplateVar "first"
+                , TemplateChunk "-"
+                , TemplateVar "known"
+                , TemplateChunk "-"
+                , TemplateVar "second"
+                ]
+        expandTemplate env tmpl
+          @?= Left (UnknownPlaceholders ["first", "second"])
+    ]
+
+defaultTemplateTests :: TestTree
+defaultTemplateTests =
+  testGroup "default template"
+    [ testCase "default template expands with required variables" $ do
+        tmplE <- loadTemplate (TemplateSpec "." DefaultTemplate)
+        tmpl <- case tmplE of
+          Left err ->
+            assertFailure ("unexpected load failure: " <> show err) >> fail "unreachable"
+          Right t ->
+            pure t
+
+        let env =
+              mkTemplateEnv
+                [ ("docs", "some docs")
+                , ("context", "{\"hole\":\"x\"}")
+                , ("numexpr", "5")
+                ]
+
+        rendered <- case expandTemplate env tmpl of
+          Left err ->
+            assertFailure ("unexpected expansion failure: " <> show err) >> fail "unreachable"
+          Right txt ->
+            pure txt
+
+        assertBool "docs substituted"
+          ("some docs" `T.isInfixOf` rendered)
+        assertBool "context substituted"
+          ("{\"hole\":\"x\"}" `T.isInfixOf` rendered)
+        assertBool "numexpr substituted"
+          ("Output a maximum of 5 expressions." `T.isInfixOf` rendered)
+
+        assertBool "no raw docs placeholder remains"
+          (not ("{{docs}}" `T.isInfixOf` rendered))
+        assertBool "no raw context placeholder remains"
+          (not ("{{context}}" `T.isInfixOf` rendered))
+        assertBool "no raw numexpr placeholder remains"
+          (not ("{{numexpr}}" `T.isInfixOf` rendered))
+
+    , testCase "default template expansion fails if required placeholders are missing" $ do
+        tmplE <- loadTemplate (TemplateSpec "." DefaultTemplate)
+        tmpl <- case tmplE of
+          Left err ->
+            assertFailure ("unexpected load failure: " <> show err) >> fail "unreachable"
+          Right t ->
+            pure t
+
+        let env = mkTemplateEnv []
+
+        expandTemplate env tmpl
+          @?= Left (UnknownPlaceholders ["docs", "context", "numexpr"])
+    ]

--- a/spec/GHC/Plugin/OllamaHoles/Template/Load/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Template/Load/Spec.hs
@@ -35,7 +35,7 @@ loadTemplateTests =
         result <- loadTemplate (TemplateSpec "" DefaultTemplate)
         case result of
           Right (Template txt) ->
-            assertBool "expected non-empty default template" (not (T.null txt))
+            assertBool "expected non-empty default template" (not (null txt))
           Left err ->
             assertFailure ("expected default template to load, got: " <> show err)
 
@@ -44,7 +44,7 @@ loadTemplateTests =
           let fp = dir </> "prompt.txt"
           writeFile fp "hello {{name}}"
           result <- loadTemplate (TemplateSpec dir (TemplateFile fp))
-          result @?= Right (Template "hello {{name}}")
+          result @?= Right (Template [TemplateChunk "hello ", TemplateVar "name"])
 
     , testCase "TemplateFile reports missing file" $
         withSystemTempDirectory "ollama-holes-template-spec" $ \dir -> do
@@ -57,7 +57,7 @@ loadTemplateTests =
           let fp = dir </> "qwen.txt"
           writeFile fp "hello {{context}}"
           result <- loadTemplate (TemplateSpec dir (NamedTemplate "qwen"))
-          result @?= Right (Template "hello {{context}}")
+          result @?= Right (Template [TemplateChunk "hello ", TemplateVar "context"])
 
     , testCase "NamedTemplate reports unknown name" $
         withSystemTempDirectory "ollama-holes-template-spec" $ \dir -> do
@@ -76,9 +76,8 @@ loadAndParseTests =
           case loaded of
             Left err ->
               assertFailure ("unexpected load error: " <> show err)
-            Right tmpl ->
-              parseTemplate tmpl @?=
-                Right
+            Right (Template exprs) ->
+              exprs @?=
                   [ TemplateChunk "A "
                   , TemplateVar (Placeholder "foo")
                   , TemplateChunk " B "
@@ -91,15 +90,8 @@ loadAndParseTests =
         case loaded of
           Left err ->
             assertFailure ("unexpected load error: " <> show err)
-          Right tmpl ->
-            case parseTemplate tmpl of
-              Left err ->
-                assertFailure ("default template failed to parse: " <> show err)
-              Right exprs -> do
-                let vars =
-                      [ v
-                      | TemplateVar v <- exprs
-                      ]
+          Right (Template exprs) -> do
+                let vars = [ v | TemplateVar v <- exprs ]
                 assertBool
                   ("expected docs placeholder in default template, saw: " <> show vars)
                   (Placeholder "docs" `elem` vars)
@@ -113,16 +105,11 @@ loadAndParseTests =
     , testCase "default template includes at least one variable" $ do
         loaded <- loadTemplate (TemplateSpec "" DefaultTemplate)
         case loaded of
-          Left err ->
-            assertFailure ("unexpected load error: " <> show err)
-          Right tmpl ->
-            case parseTemplate tmpl of
-              Left err ->
-                assertFailure ("default template failed to parse: " <> show err)
-              Right exprs ->
-                assertBool
-                  "expected at least one TemplateVar in default template"
-                  (any isVar exprs)
+            Left err ->
+                assertFailure ("unexpected load error: " <> show err)
+            Right (Template exprs) -> assertBool
+                "expected at least one TemplateVar in default template"
+                (any isVar exprs)
     ]
   where
     isVar (TemplateVar _) = True

--- a/spec/GHC/Plugin/OllamaHoles/Template/Load/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Template/Load/Spec.hs
@@ -19,6 +19,7 @@ import GHC.Plugin.OllamaHoles.Template
   , TemplateParseError(..)
   , loadTemplate
   , parseTemplate
+  , unsafeCreateRawTemplateName
   )
 
 tests :: TestTree
@@ -56,13 +57,41 @@ loadTemplateTests =
         withSystemTempDirectory "ollama-holes-template-spec" $ \dir -> do
           let fp = dir </> "qwen.txt"
           writeFile fp "hello {{context}}"
-          result <- loadTemplate (TemplateSpec dir (NamedTemplate "qwen"))
+          result <- loadTemplate (TemplateSpec dir (NamedTemplate $ unsafeCreateRawTemplateName "qwen"))
           result @?= Right (Template [TemplateChunk "hello ", TemplateVar "context"])
 
     , testCase "NamedTemplate reports unknown name" $
         withSystemTempDirectory "ollama-holes-template-spec" $ \dir -> do
-          result <- loadTemplate (TemplateSpec dir (NamedTemplate "missing"))
+          result <- loadTemplate (TemplateSpec dir (NamedTemplate $ unsafeCreateRawTemplateName "missing"))
           result @?= Left (UnknownTemplateName dir "missing")
+
+    , testCase "NamedTemplate rejects path traversal with .." $
+        withSystemTempDirectory "ollama-holes-template-spec" $ \dir -> do
+            result <- loadTemplate (TemplateSpec dir (NamedTemplate $ unsafeCreateRawTemplateName "../../secret"))
+            result @?= Left (InvalidTemplateName "../../secret")
+
+    , testCase "NamedTemplate rejects slash" $
+        withSystemTempDirectory "ollama-holes-template-spec" $ \dir -> do
+            result <- loadTemplate (TemplateSpec dir (NamedTemplate $ unsafeCreateRawTemplateName "foo/bar"))
+            result @?= Left (InvalidTemplateName "foo/bar")
+
+    , testCase "NamedTemplate rejects backslash" $
+        withSystemTempDirectory "ollama-holes-template-spec" $ \dir -> do
+            result <- loadTemplate (TemplateSpec dir (NamedTemplate $ unsafeCreateRawTemplateName "foo\\bar"))
+            result @?= Left (InvalidTemplateName "foo\\bar")
+
+    , testCase "NamedTemplate rejects empty name" $
+        withSystemTempDirectory "ollama-holes-template-spec" $ \dir -> do
+            result <- loadTemplate (TemplateSpec dir (NamedTemplate $ unsafeCreateRawTemplateName ""))
+            result @?= Left (InvalidTemplateName "")
+
+    , testCase "NamedTemplate accepts simple safe name" $
+        withSystemTempDirectory "ollama-holes-template-spec" $ \dir -> do
+            writeFile (dir </> "qwen_3.txt") "hello {{context}}"
+            result <- loadTemplate (TemplateSpec dir (NamedTemplate $ unsafeCreateRawTemplateName "qwen_3"))
+            case result of
+                Right _ -> pure ()
+                Left err -> assertFailure ("unexpected error: " <> show err)
     ]
 
 loadAndParseTests :: TestTree

--- a/spec/GHC/Plugin/OllamaHoles/Template/Load/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Template/Load/Spec.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module GHC.Plugin.OllamaHoles.Template.Load.Spec (tests) where
+
+import Data.List qualified as L
+import Data.Text qualified as T
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import GHC.Plugin.OllamaHoles.Template
+  ( Template(..)
+  , TemplateSpec(..)
+  , TemplateSource(..)
+  , TemplateError(..)
+  , TemplateExpr(..)
+  , Placeholder(..)
+  , TemplateParseError(..)
+  , loadTemplate
+  , parseTemplate
+  )
+
+tests :: TestTree
+tests =
+  testGroup "Template"
+    [ loadTemplateTests
+    , loadAndParseTests
+    ]
+
+loadTemplateTests :: TestTree
+loadTemplateTests =
+  testGroup "loadTemplate"
+    [ testCase "DefaultTemplate loads successfully" $ do
+        result <- loadTemplate (TemplateSpec "" DefaultTemplate)
+        case result of
+          Right (Template txt) ->
+            assertBool "expected non-empty default template" (not (T.null txt))
+          Left err ->
+            assertFailure ("expected default template to load, got: " <> show err)
+
+    , testCase "TemplateFile loads an existing file" $
+        withSystemTempDirectory "ollama-holes-template-spec" $ \dir -> do
+          let fp = dir </> "prompt.txt"
+          writeFile fp "hello {{name}}"
+          result <- loadTemplate (TemplateSpec dir (TemplateFile fp))
+          result @?= Right (Template "hello {{name}}")
+
+    , testCase "TemplateFile reports missing file" $
+        withSystemTempDirectory "ollama-holes-template-spec" $ \dir -> do
+          let fp = dir </> "missing.txt"
+          result <- loadTemplate (TemplateSpec dir (TemplateFile fp))
+          result @?= Left (TemplateFileNotFound fp)
+
+    , testCase "NamedTemplate loads <searchDir>/<name>.txt" $
+        withSystemTempDirectory "ollama-holes-template-spec" $ \dir -> do
+          let fp = dir </> "qwen.txt"
+          writeFile fp "hello {{context}}"
+          result <- loadTemplate (TemplateSpec dir (NamedTemplate "qwen"))
+          result @?= Right (Template "hello {{context}}")
+
+    , testCase "NamedTemplate reports unknown name" $
+        withSystemTempDirectory "ollama-holes-template-spec" $ \dir -> do
+          result <- loadTemplate (TemplateSpec dir (NamedTemplate "missing"))
+          result @?= Left (UnknownTemplateName dir "missing")
+    ]
+
+loadAndParseTests :: TestTree
+loadAndParseTests =
+  testGroup "load + parse"
+    [ testCase "loaded file parses into expected chunks and vars" $
+        withSystemTempDirectory "ollama-holes-template-spec" $ \dir -> do
+          let fp = dir </> "prompt.txt"
+          writeFile fp "A {{foo}} B {{bar}}."
+          loaded <- loadTemplate (TemplateSpec dir (TemplateFile fp))
+          case loaded of
+            Left err ->
+              assertFailure ("unexpected load error: " <> show err)
+            Right tmpl ->
+              parseTemplate tmpl @?=
+                Right
+                  [ TemplateChunk "A "
+                  , TemplateVar (Placeholder "foo")
+                  , TemplateChunk " B "
+                  , TemplateVar (Placeholder "bar")
+                  , TemplateChunk "."
+                  ]
+
+    , testCase "default template parses placeholders for docs/context/numexpr" $ do
+        loaded <- loadTemplate (TemplateSpec "" DefaultTemplate)
+        case loaded of
+          Left err ->
+            assertFailure ("unexpected load error: " <> show err)
+          Right tmpl ->
+            case parseTemplate tmpl of
+              Left err ->
+                assertFailure ("default template failed to parse: " <> show err)
+              Right exprs -> do
+                let vars =
+                      [ v
+                      | TemplateVar v <- exprs
+                      ]
+                assertBool
+                  ("expected docs placeholder in default template, saw: " <> show vars)
+                  (Placeholder "docs" `elem` vars)
+                assertBool
+                  ("expected context placeholder in default template, saw: " <> show vars)
+                  (Placeholder "context" `elem` vars)
+                assertBool
+                  ("expected numexpr placeholder in default template, saw: " <> show vars)
+                  (Placeholder "numexpr" `elem` vars)
+
+    , testCase "default template includes at least one variable" $ do
+        loaded <- loadTemplate (TemplateSpec "" DefaultTemplate)
+        case loaded of
+          Left err ->
+            assertFailure ("unexpected load error: " <> show err)
+          Right tmpl ->
+            case parseTemplate tmpl of
+              Left err ->
+                assertFailure ("default template failed to parse: " <> show err)
+              Right exprs ->
+                assertBool
+                  "expected at least one TemplateVar in default template"
+                  (any isVar exprs)
+    ]
+  where
+    isVar (TemplateVar _) = True
+    isVar _               = False

--- a/spec/GHC/Plugin/OllamaHoles/Template/Parse/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Template/Parse/Spec.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module GHC.Plugin.OllamaHoles.Template.Parse.Spec (tests) where
+
+import Data.Char (isAlpha, isAscii)
+import Data.Text qualified as T
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck qualified as QC
+
+import GHC.Plugin.OllamaHoles.Template
+  ( Template(..)
+  , TemplateExpr(..)
+  , Placeholder(..)
+  , TemplateError(..)
+  , TemplateParseError(..)
+  , parseTemplate
+  )
+
+tests :: TestTree
+tests =
+  testGroup "Template parser"
+    [ unitTests
+    , propertyTests
+    ]
+
+unitTests :: TestTree
+unitTests =
+  testGroup "unit"
+    [ testCase "empty template parses to empty token list" $
+        parseTemplate (Template "") @?= Right []
+
+    , testCase "plain text parses to one chunk" $
+        parseTemplate (Template "hello world")
+          @?= Right [TemplateChunk "hello world"]
+
+    , testCase "single placeholder parses" $
+        parseTemplate (Template "{{name}}")
+          @?= Right [TemplateVar (Placeholder "name")]
+
+    , testCase "text around placeholder parses" $
+        parseTemplate (Template "hello {{name}}!")
+          @?=
+            Right
+              [ TemplateChunk "hello "
+              , TemplateVar (Placeholder "name")
+              , TemplateChunk "!"
+              ]
+
+    , testCase "adjacent placeholders parse" $
+        parseTemplate (Template "{{foo}}{{bar}}")
+          @?=
+            Right
+              [ TemplateVar (Placeholder "foo")
+              , TemplateVar (Placeholder "bar")
+              ]
+
+    , testCase "multiple chunks and placeholders parse" $
+        parseTemplate (Template "a{{x}}b{{y}}c")
+          @?=
+            Right
+              [ TemplateChunk "a"
+              , TemplateVar (Placeholder "x")
+              , TemplateChunk "b"
+              , TemplateVar (Placeholder "y")
+              , TemplateChunk "c"
+              ]
+
+    , testCase "empty placeholder is rejected" $
+        parseTemplate (Template "{{}}")
+          @?= Left (MalformedTemplate 0 0 (MalformedPlaceholder ""))
+
+    , testCase "placeholder with hyphen is rejected" $
+        parseTemplate (Template "{{foo-bar}}")
+          @?= Left (MalformedTemplate 0 0 (MalformedPlaceholder "foo-bar"))
+
+    , testCase "placeholder with space is rejected" $
+        parseTemplate (Template "{{foo bar}}")
+          @?= Left (MalformedTemplate 0 0 (MalformedPlaceholder "foo bar"))
+
+    , testCase "unclosed placeholder is rejected" $
+        parseTemplate (Template "{{foo")
+          @?= Left (MalformedTemplate 0 0 (MalformedPlaceholder "foo"))
+
+    , testCase "lone opening brace stays ordinary text" $
+        parseTemplate (Template "{foo")
+          @?= Right [TemplateChunk "{foo"]
+
+    , testCase "single braces around name stay ordinary text" $
+        parseTemplate (Template "{name}")
+          @?= Right [TemplateChunk "{name}"]
+
+    , testCase "malformed placeholder after prefix reports start position" $
+        parseTemplate (Template "abc{{foo-bar}}")
+          @?= Left (MalformedTemplate 0 3 (MalformedPlaceholder "foo-bar"))
+
+    , testCase "malformed placeholder after newline reports line and column" $
+        parseTemplate (Template "abc\n{{foo-bar}}")
+          @?= Left (MalformedTemplate 1 0 (MalformedPlaceholder "foo-bar"))
+
+    , testCase "valid placeholder after newline reports no error" $
+        parseTemplate (Template "abc\n{{foo}}")
+          @?=
+            Right
+              [ TemplateChunk "abc\n"
+              , TemplateVar (Placeholder "foo")
+              ]
+    ]
+
+propertyTests :: TestTree
+propertyTests =
+  testGroup "properties"
+    [ QC.testProperty "nonempty plain ascii text without '{{' parses as a single chunk" $
+        QC.forAll genPlainChunk1 $ \s ->
+          parseTemplate (Template (T.pack s))
+            == Right [TemplateChunk (T.pack s)]
+
+    , QC.testProperty "valid placeholder names parse as variables" $
+        QC.forAll genPlaceholderName $ \nm ->
+          parseTemplate (Template ("{{" <> T.pack nm <> "}}"))
+            == Right [TemplateVar (Placeholder (T.pack nm))]
+    ]
+
+genPlainChunk1 :: QC.Gen String
+genPlainChunk1 =
+    fmap concat $ QC.listOf1 $
+        -- ensure we never generate two consecutive '{'
+        QC.oneof [pure (:[]), pure (:['{'])]
+            <*> QC.suchThat QC.arbitrary (/= '{')
+
+genPlaceholderName :: QC.Gen String
+genPlaceholderName = QC.listOf1 $
+    QC.suchThat QC.arbitrary (\c -> isAscii c && isAlpha c)

--- a/spec/GHC/Plugin/OllamaHoles/Template/Parse/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Template/Parse/Spec.hs
@@ -28,83 +28,83 @@ unitTests :: TestTree
 unitTests =
   testGroup "unit"
     [ testCase "empty template parses to empty token list" $
-        parseTemplate (Template "") @?= Right []
+        parseTemplate "" @?= Right (Template [])
 
     , testCase "plain text parses to one chunk" $
-        parseTemplate (Template "hello world")
-          @?= Right [TemplateChunk "hello world"]
+        parseTemplate "hello world"
+          @?= Right (Template [TemplateChunk "hello world"])
 
     , testCase "single placeholder parses" $
-        parseTemplate (Template "{{name}}")
-          @?= Right [TemplateVar (Placeholder "name")]
+        parseTemplate "{{name}}"
+          @?= Right (Template [TemplateVar (Placeholder "name")])
 
     , testCase "text around placeholder parses" $
-        parseTemplate (Template "hello {{name}}!")
+        parseTemplate "hello {{name}}!"
           @?=
-            Right
+            Right (Template
               [ TemplateChunk "hello "
               , TemplateVar (Placeholder "name")
               , TemplateChunk "!"
-              ]
+              ])
 
     , testCase "adjacent placeholders parse" $
-        parseTemplate (Template "{{foo}}{{bar}}")
+        parseTemplate "{{foo}}{{bar}}"
           @?=
-            Right
+            Right (Template
               [ TemplateVar (Placeholder "foo")
               , TemplateVar (Placeholder "bar")
-              ]
+              ])
 
     , testCase "multiple chunks and placeholders parse" $
-        parseTemplate (Template "a{{x}}b{{y}}c")
+        parseTemplate "a{{x}}b{{y}}c"
           @?=
-            Right
+            Right (Template
               [ TemplateChunk "a"
               , TemplateVar (Placeholder "x")
               , TemplateChunk "b"
               , TemplateVar (Placeholder "y")
               , TemplateChunk "c"
-              ]
+              ])
 
     , testCase "empty placeholder is rejected" $
-        parseTemplate (Template "{{}}")
+        parseTemplate "{{}}"
           @?= Left (MalformedTemplate 0 0 (MalformedPlaceholder ""))
 
     , testCase "placeholder with hyphen is rejected" $
-        parseTemplate (Template "{{foo-bar}}")
+        parseTemplate "{{foo-bar}}"
           @?= Left (MalformedTemplate 0 0 (MalformedPlaceholder "foo-bar"))
 
     , testCase "placeholder with space is rejected" $
-        parseTemplate (Template "{{foo bar}}")
+        parseTemplate "{{foo bar}}"
           @?= Left (MalformedTemplate 0 0 (MalformedPlaceholder "foo bar"))
 
     , testCase "unclosed placeholder is rejected" $
-        parseTemplate (Template "{{foo")
+        parseTemplate "{{foo"
           @?= Left (MalformedTemplate 0 0 (MalformedPlaceholder "foo"))
 
     , testCase "lone opening brace stays ordinary text" $
-        parseTemplate (Template "{foo")
-          @?= Right [TemplateChunk "{foo"]
+        parseTemplate "{foo"
+          @?= Right (Template [TemplateChunk "{foo"])
 
     , testCase "single braces around name stay ordinary text" $
-        parseTemplate (Template "{name}")
-          @?= Right [TemplateChunk "{name}"]
+        parseTemplate "{name}"
+          @?= Right (Template [TemplateChunk "{name}"])
 
     , testCase "malformed placeholder after prefix reports start position" $
-        parseTemplate (Template "abc{{foo-bar}}")
+        parseTemplate "abc{{foo-bar}}"
           @?= Left (MalformedTemplate 0 3 (MalformedPlaceholder "foo-bar"))
 
     , testCase "malformed placeholder after newline reports line and column" $
-        parseTemplate (Template "abc\n{{foo-bar}}")
+        parseTemplate "abc\n{{foo-bar}}"
           @?= Left (MalformedTemplate 1 0 (MalformedPlaceholder "foo-bar"))
 
     , testCase "valid placeholder after newline reports no error" $
-        parseTemplate (Template "abc\n{{foo}}")
+        parseTemplate "abc\n{{foo}}"
           @?=
-            Right
+            Right (Template
               [ TemplateChunk "abc\n"
               , TemplateVar (Placeholder "foo")
-              ]
+              ])
     ]
 
 propertyTests :: TestTree
@@ -112,13 +112,13 @@ propertyTests =
   testGroup "properties"
     [ QC.testProperty "nonempty plain ascii text without '{{' parses as a single chunk" $
         QC.forAll genPlainChunk1 $ \s ->
-          parseTemplate (Template (T.pack s))
-            == Right [TemplateChunk (T.pack s)]
+          parseTemplate (T.pack s)
+            == Right (Template [TemplateChunk (T.pack s)])
 
     , QC.testProperty "valid placeholder names parse as variables" $
         QC.forAll genPlaceholderName $ \nm ->
-          parseTemplate (Template ("{{" <> T.pack nm <> "}}"))
-            == Right [TemplateVar (Placeholder (T.pack nm))]
+          parseTemplate ("{{" <> T.pack nm <> "}}")
+            == Right (Template [TemplateVar (Placeholder (T.pack nm))])
     ]
 
 genPlainChunk1 :: QC.Gen String

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -6,6 +6,7 @@ import qualified GHC.Plugin.OllamaHoles.Candidate.Normalize.Spec as NormalizeSpe
 import qualified GHC.Plugin.OllamaHoles.Candidate.Rewrite.Spec as RewriteSpec
 import qualified GHC.Plugin.OllamaHoles.Candidate.Compat.Spec as CompatSpec
 import qualified GHC.Plugin.OllamaHoles.Template.Parse.Spec as ParseSpec
+import qualified GHC.Plugin.OllamaHoles.Template.Load.Spec as LoadSpec
 
 main :: IO ()
 main = defaultMain $
@@ -15,4 +16,5 @@ main = defaultMain $
         , RewriteSpec.tests
         , CompatSpec.tests
         , ParseSpec.tests
+        , LoadSpec.tests
         ]

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -5,6 +5,7 @@ import qualified GHC.Plugin.OllamaHoles.Candidate.Spec as CandidateSpec
 import qualified GHC.Plugin.OllamaHoles.Candidate.Normalize.Spec as NormalizeSpec
 import qualified GHC.Plugin.OllamaHoles.Candidate.Rewrite.Spec as RewriteSpec
 import qualified GHC.Plugin.OllamaHoles.Candidate.Compat.Spec as CompatSpec
+import qualified GHC.Plugin.OllamaHoles.Template.Parse.Spec as ParseSpec
 
 main :: IO ()
 main = defaultMain $
@@ -13,4 +14,5 @@ main = defaultMain $
         , NormalizeSpec.tests
         , RewriteSpec.tests
         , CompatSpec.tests
+        , ParseSpec.tests
         ]

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -7,6 +7,7 @@ import qualified GHC.Plugin.OllamaHoles.Candidate.Rewrite.Spec as RewriteSpec
 import qualified GHC.Plugin.OllamaHoles.Candidate.Compat.Spec as CompatSpec
 import qualified GHC.Plugin.OllamaHoles.Template.Parse.Spec as ParseSpec
 import qualified GHC.Plugin.OllamaHoles.Template.Load.Spec as LoadSpec
+import qualified GHC.Plugin.OllamaHoles.Template.Expand.Spec as ExpandSpec
 import qualified GHC.Plugin.OllamaHoles.Options.Spec as OptionsSpec
 
 main :: IO ()
@@ -18,5 +19,6 @@ main = defaultMain $
         , CompatSpec.tests
         , ParseSpec.tests
         , LoadSpec.tests
+        , ExpandSpec.tests
         , OptionsSpec.tests
         ]

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -7,6 +7,7 @@ import qualified GHC.Plugin.OllamaHoles.Candidate.Rewrite.Spec as RewriteSpec
 import qualified GHC.Plugin.OllamaHoles.Candidate.Compat.Spec as CompatSpec
 import qualified GHC.Plugin.OllamaHoles.Template.Parse.Spec as ParseSpec
 import qualified GHC.Plugin.OllamaHoles.Template.Load.Spec as LoadSpec
+import qualified GHC.Plugin.OllamaHoles.Options.Spec as OptionsSpec
 
 main :: IO ()
 main = defaultMain $
@@ -17,4 +18,5 @@ main = defaultMain $
         , CompatSpec.tests
         , ParseSpec.tests
         , LoadSpec.tests
+        , OptionsSpec.tests
         ]

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -55,6 +55,7 @@ import qualified Data.Aeson as Aeson
 import           GHC.Plugin.OllamaHoles.Prompt
 import qualified GHC.Plugin.OllamaHoles.Logger as Log
 import           GHC.Plugin.OllamaHoles.Candidate
+import           GHC.Plugin.OllamaHoles.Template
 
 -- | Prompt used to prompt the LLM
 promptTemplate :: Text
@@ -84,9 +85,10 @@ getBackend Flags{backend_name = "openai", ..} = openAICompatibleBackend openai_b
 getBackend Flags{..} = error $ "unknown backend: " <> T.unpack backend_name
 
 data PluginState = PluginState
-  { candidates    :: [HoleFitCandidate]
-  , writeLogEvent :: Log.Logger
-  }
+    { candidates     :: [HoleFitCandidate]
+    , writeLogEvent  :: Log.Logger
+    , parsedTemplate :: [TemplateExpr]
+    }
 
 -- | Ollama plugin for GHC
 plugin :: Plugin
@@ -100,7 +102,7 @@ mkHoleFitPluginR
 mkHoleFitPluginR opts =
     Just $
         HoleFitPluginR
-            { hfPluginInit = hfPluginInitLLM
+            { hfPluginInit = hfPluginInitLLM opts
             , hfPluginStop = \_ -> return ()
             , hfPluginRun = \ref ->
                     HoleFitPlugin
@@ -109,12 +111,19 @@ mkHoleFitPluginR opts =
                         }
             }
 
-hfPluginInitLLM :: TcM (TcRef PluginState)
-hfPluginInitLLM = do
+hfPluginInitLLM :: [CommandLineOption] -> TcM (TcRef PluginState)
+hfPluginInitLLM opts = do
+    let flags = parseFlags opts
     logger <- liftIO Log.initLogger
+    template <- liftIO $ do
+        raw <- loadTemplate (mkTemplateSpec flags)
+        case raw >>= parseTemplate of
+            Left err -> error $ "template parse error: " <> show err
+            Right ok -> pure ok
     newTcRef $ PluginState
         { candidates    = []
         , writeLogEvent = logger
+        , parsedTemplate = template
         }
 
 pluginName :: Text
@@ -127,7 +136,7 @@ fitPluginLLM
     -> [HoleFit]
     -> GHC.IOEnv (Env TcGblEnv TcLclEnv) [HoleFit]
 fitPluginLLM opts ref hole fits = do
-    PluginState cands logger <- readTcRef ref
+    PluginState cands logger template <- readTcRef ref
     let flags@Flags{..} = parseFlags opts
     dflags <- getDynFlags
     gbl_env <- getGblEnv
@@ -159,19 +168,23 @@ fitPluginLLM opts ref hole fits = do
                 Just h -> do
                     docs <- if include_docs then getDocs cands else return ""
 
-                    let promptContext' = T.unpack $ maybe "" encodePromptContext promptContext
-                    let prompt' =
-                            replacePlaceholders
-                                promptTemplate
-                                [ ("{numexpr}", show num_expr)
-                                , ("{docs}", docs)
-                                , ("{context}", promptContext')
-                                ]
-                    liftIO $ when debug $ do T.putStrLn $ pluginName <> " Prompt:\n```\n" <> prompt' <> "\n```"
-                    res <- liftIO $ generateFits backend prompt' model_name model_options
+                    let promptContext'' = maybe "" encodePromptContext promptContext
+                    let env = mkTemplateEnv
+                            [ ("context" , promptContext'')
+                            , ("docs"    , T.pack docs)
+                            , ("numexpr" , T.pack (show num_expr))
+                            , ("backend" , backend_name)
+                            , ("model"   , model_name)
+                            , ("guidance", maybe "" (mconcat . pcGuidance) promptContext)
+                            ]
+                    prompt'' <- case expandTemplateExprs env template of
+                        Left err -> error $ "Template substitution error: " <> show err
+                        Right ok -> pure ok
+                    liftIO $ when debug $ do T.putStrLn $ "NEW PROMPT:\n\n" <> prompt'' <> "\n\n"
+                    res <- liftIO $ generateFits backend prompt'' model_name model_options
                     case res of
                         Right rsp ->
-                            extractHoleFitsFromResponse dflags prompt' rsp logger hole h debug
+                            extractHoleFitsFromResponse dflags prompt'' rsp logger hole h debug
                         Left err -> do
                             liftIO $
                                 when debug $
@@ -345,6 +358,9 @@ data Flags = Flags
     , openai_base_url :: Text
     , openai_key_name :: Text
     , model_options :: Maybe Value
+    , template_path     :: Maybe FilePath
+    , template_name     :: Maybe Text
+    , template_search_dir :: FilePath
     } deriving (Show)
 
 -- | Default flags for the plugin
@@ -359,6 +375,9 @@ defaultFlags =
         , openai_base_url = "https://api.openai.com"
         , openai_key_name = "OPENAI_API_KEY"
         , model_options = Nothing
+        , template_path = Nothing
+        , template_name = Nothing
+        , template_search_dir = "."
         }
 
 -- | Produce the documentation of all the HolefitCandidates.
@@ -428,11 +447,26 @@ parseFlags = parseFlags' defaultFlags . reverse -- reverse so outside options co
             in case m_opts of
                 Right o -> parseFlags' flags{model_options = Just o } opts
                 Left err -> error $ "Failed to parse model-options: " <> err
+    parseFlags' flags (opt : opts)
+        | T.isPrefixOf "template=" (T.pack opt) =
+            let template_path = Just . T.unpack $ T.drop (T.length "template=") (T.pack opt)
+            in parseFlags' flags{template_path = template_path, template_name = Nothing} opts
+    parseFlags' flags (opt : opts)
+        | T.isPrefixOf "template-name=" (T.pack opt) =
+            let template_name = Just $ T.drop (T.length "template-name=") (T.pack opt)
+            in parseFlags' flags{template_name = template_name, template_path = Nothing} opts
+    parseFlags' flags (opt : opts)
+        | T.isPrefixOf "template-dir=" (T.pack opt) =
+            let template_search_dir = T.unpack $ T.drop (T.length "template-dir=") (T.pack opt)
+            in parseFlags' flags{template_search_dir = template_search_dir} opts
     parseFlags' flags _ = flags
 
--- | Helper function to replace placeholders in a template string
-replacePlaceholders :: Text -> [(Text, String)] -> Text
-replacePlaceholders = foldl replacePlaceholder
-  where
-    replacePlaceholder :: Text -> (Text, String) -> Text
-    replacePlaceholder str (placeholder, value) = T.replace placeholder (T.pack value) str
+-- | Helper function to interpret a @TemplateSpec@ from the flags.
+mkTemplateSpec :: Flags -> TemplateSpec
+mkTemplateSpec Flags{..} =TemplateSpec
+    { tsSearchDir = template_search_dir
+    , tsSource = case (template_path, template_name) of
+          (Just fp, _) -> TemplateFile fp
+          (_, Just nm) -> NamedTemplate nm
+          _            -> DefaultTemplate
+    }

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -57,25 +57,7 @@ import qualified GHC.Plugin.OllamaHoles.Logger as Log
 import           GHC.Plugin.OllamaHoles.Candidate
 import           GHC.Plugin.OllamaHoles.Template
 
--- | Prompt used to prompt the LLM
-promptTemplate :: Text
-promptTemplate =
-           "Preliminaries:"
-        <> "{docs}\n\n"
-        <> "--------------------------------------------------------------------\n"
-        <> "You are a typed-hole plugin within GHC, the Glasgow Haskell Compiler.\n"
-        <> "You are given a hole in a Haskell program, and you need to fill it in.\n"
-        <> "The hole is represented by the following JSON encoded information:\n"
-        <> "{context}\n\n"
-        <> "Provide one or more Haskell expressions that could fill this hole.\n"
-        <> "This means coming up with an expression of the correct type that satisfies the constraints.\n"
-        <> "Pay special attention to the type of the hole, specifically whether it is a function.\n"
-        <> "Make sure you synthesize an expression that matches the type of the hole.\n"
-        <> "Output ONLY the raw Haskell expression(s), one per line.\n"
-        <> "Do not try to bind the hole variable, e.g. `_b = ...`. Produce only the expression.\n"
-        <> "Do not include explanations, introductions, or any surrounding text.\n"
-        <> "If you are using a function from scope, make sure to use the qualified name from the list of things in scope.\n"
-        <> "Output a maximum of {numexpr} expressions.\n"
+
 
 -- | Determine which backend to use
 getBackend :: Flags -> Backend
@@ -87,7 +69,8 @@ getBackend Flags{..} = error $ "unknown backend: " <> T.unpack backend_name
 data PluginState = PluginState
     { candidates     :: [HoleFitCandidate]
     , writeLogEvent  :: Log.Logger
-    , parsedTemplate :: [TemplateExpr]
+    , templateSpec   :: TemplateSpec
+    , parsedTemplate :: Template
     }
 
 -- | Ollama plugin for GHC
@@ -114,15 +97,17 @@ mkHoleFitPluginR opts =
 hfPluginInitLLM :: [CommandLineOption] -> TcM (TcRef PluginState)
 hfPluginInitLLM opts = do
     let flags = parseFlags opts
+    let spec = mkTemplateSpec flags
     logger <- liftIO Log.initLogger
     template <- liftIO $ do
-        raw <- loadTemplate (mkTemplateSpec flags)
-        case raw >>= parseTemplate of
+        raw <- loadTemplate spec
+        case raw of
             Left err -> error $ "template parse error: " <> show err
             Right ok -> pure ok
     newTcRef $ PluginState
         { candidates    = []
         , writeLogEvent = logger
+        , templateSpec = spec
         , parsedTemplate = template
         }
 
@@ -136,7 +121,7 @@ fitPluginLLM
     -> [HoleFit]
     -> GHC.IOEnv (Env TcGblEnv TcLclEnv) [HoleFit]
 fitPluginLLM opts ref hole fits = do
-    PluginState cands logger template <- readTcRef ref
+    PluginState cands logger templateSpec template <- readTcRef ref
     let flags@Flags{..} = parseFlags opts
     dflags <- getDynFlags
     gbl_env <- getGblEnv
@@ -177,7 +162,7 @@ fitPluginLLM opts ref hole fits = do
                             , ("model"   , model_name)
                             , ("guidance", maybe "" (mconcat . pcGuidance) promptContext)
                             ]
-                    prompt'' <- case expandTemplateExprs env template of
+                    prompt'' <- case expandTemplate env template of
                         Left err -> error $ "Template substitution error: " <> show err
                         Right ok -> pure ok
                     liftIO $ when debug $ do T.putStrLn $ "NEW PROMPT:\n\n" <> prompt'' <> "\n\n"

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -97,7 +97,9 @@ mkHoleFitPluginR opts =
 hfPluginInitLLM :: [CommandLineOption] -> TcM (TcRef PluginState)
 hfPluginInitLLM opts = do
     let flags = parseFlags opts
-    let spec = mkTemplateSpec flags
+    spec <- case mkTemplateSpec flags of
+        Left err -> error $ "Template spec error: " <> show err
+        Right ok -> pure ok
     logger <- liftIO Log.initLogger
     template <- liftIO $ do
         raw <- loadTemplate spec
@@ -447,11 +449,14 @@ parseFlags = parseFlags' defaultFlags . reverse -- reverse so outside options co
     parseFlags' flags _ = flags
 
 -- | Helper function to interpret a @TemplateSpec@ from the flags.
-mkTemplateSpec :: Flags -> TemplateSpec
-mkTemplateSpec Flags{..} =TemplateSpec
-    { tsSearchDir = template_search_dir
-    , tsSource = case (template_path, template_name) of
-          (Just fp, _) -> TemplateFile fp
-          (_, Just nm) -> NamedTemplate $ parseTemplateName nm
-          _            -> DefaultTemplate
-    }
+mkTemplateSpec :: Flags -> Either TemplateError TemplateSpec
+mkTemplateSpec Flags{..} = do
+    let mkSpec source = TemplateSpec
+            { tsSearchDir = template_search_dir
+            , tsSource = source
+            }
+    case (template_path, template_name) of
+        (Just fp, _) -> Right $ mkSpec $ TemplateFile fp
+        (_, Just nm) -> fmap (mkSpec . NamedTemplate) $ parseTemplateName nm
+        _            -> Right $ mkSpec $ DefaultTemplate
+

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -452,6 +452,6 @@ mkTemplateSpec Flags{..} =TemplateSpec
     { tsSearchDir = template_search_dir
     , tsSource = case (template_path, template_name) of
           (Just fp, _) -> TemplateFile fp
-          (_, Just nm) -> NamedTemplate nm
+          (_, Just nm) -> NamedTemplate $ parseTemplateName nm
           _            -> DefaultTemplate
     }

--- a/src/GHC/Plugin/OllamaHoles/Template.hs
+++ b/src/GHC/Plugin/OllamaHoles/Template.hs
@@ -1,15 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module GHC.Plugin.OllamaHoles.Template
     ( Template(..)
     , TemplateSpec(..)
     , TemplateSource(..)
     , TemplateError(..)
+    , TemplateExpr(..)
+    , Placeholder(..)
+    , TemplateParseError(..)
     , loadTemplate
+    , parseTemplate
     ) where
 
+import Data.Char (isAlpha, isAscii)
+import Data.Map (Map)
+import Data.Map qualified as M
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import System.Directory (doesFileExist)
+import System.FilePath ((</>))
 
 
 
@@ -26,7 +36,7 @@ data TemplateSpec = TemplateSpec
     } deriving (Eq, Show)
 
 data TemplateSource
-    = DefaultTemplate       -- Used if the spec is missing or malformed
+    = DefaultTemplate       -- Used if the spec is not specified
     | TemplateFile FilePath -- When using a specific template by path
     | NamedTemplate Text    -- When using a template by name in @tsSearchDir@
     deriving (Eq, Show)
@@ -34,6 +44,8 @@ data TemplateSource
 data TemplateError
     = TemplateFileNotFound FilePath
     | UnknownTemplateName FilePath Text
+    | UnknownPlaceholders [Placeholder]
+    | MalformedTemplate Line Col TemplateParseError
     deriving (Eq, Show)
 
 loadTemplate :: TemplateSpec -> IO (Either TemplateError Template)
@@ -53,11 +65,142 @@ loadTemplate spec = do
                 else pure $ Left $ TemplateFileNotFound path
 
         NamedTemplate name -> do
-            let path = searchDir <> "/" <> T.unpack name <> ".txt"
+            let path = searchDir </> T.unpack name <> ".txt"
             exists <- doesFileExist path
             if exists
                 then fmap (Right . Template) $ T.readFile path
                 else pure (Left (UnknownTemplateName searchDir name))
+
+
+
+-- Substitution
+---------------
+
+-- | Template variables are strings of ascii letters.
+-- They occur in the template by name wrapped in
+-- {{double_braces}}, but the braces are not part
+-- of the name.
+newtype Placeholder
+    = Placeholder Text
+    deriving (Eq, Ord)
+
+instance Show Placeholder where
+    show (Placeholder txt) = T.unpack txt
+
+data TemplateEnv
+    = TemplateEnv (Map Placeholder Text)
+    deriving (Eq, Show)
+
+lookupPlaceholder
+    :: TemplateEnv -> Placeholder -> Either Placeholder Text
+lookupPlaceholder (TemplateEnv m) name =
+    maybe (Left name) Right (M.lookup name m)
+
+data TemplateExpr
+    = TemplateChunk Text
+    | TemplateVar Placeholder
+    deriving (Eq, Show)
+
+expandTemplateExpr
+    :: TemplateEnv -> TemplateExpr -> Either Placeholder Text
+expandTemplateExpr env expr = case expr of
+    TemplateChunk txt -> Right txt
+    TemplateVar var -> lookupPlaceholder env var
+
+expandTemplateExprs
+    :: TemplateEnv -> [TemplateExpr] -> Either TemplateError Text
+expandTemplateExprs env =
+    collectEithers UnknownPlaceholders mconcat . fmap (expandTemplateExpr env)
+
+collectEithers
+    :: forall a b u v. ([a] -> u) -> ([b] -> v) -> [Either a b] -> Either u v
+collectEithers f g = go [] []
+    where
+        go :: [a] -> [b] -> [Either a b] -> Either u v
+        go as bs xs = case xs of
+            [] -> if null as
+                then Right $ g $ reverse bs
+                else Left  $ f $ reverse as
+            x:rest -> case x of
+                Left  a -> go (a:as) bs rest
+                Right b -> go as (b:bs) rest
+
+type Line = Int
+type Col  = Int
+
+data TemplateParseError
+    = MalformedPlaceholder Text
+    deriving (Eq, Ord, Show)
+
+parseTemplate
+    :: Template -> Either TemplateError [TemplateExpr]
+parseTemplate (Template raw) = go [] (T.unpack raw) 0 0
+  where
+    makeChunk, makeVar :: [Char] -> TemplateExpr
+    makeChunk = TemplateChunk . T.pack
+    makeVar   = TemplateVar . Placeholder . T.pack
+
+    validPlaceholderChar :: Char -> Bool
+    validPlaceholderChar c = isAscii c && isAlpha c
+
+    go :: [TemplateExpr] -> [Char] -> Line -> Col
+       -> Either TemplateError [TemplateExpr]
+    go tokens input ln col = case input of
+        [] ->
+            Right (reverse tokens)
+
+        '{':'{':rest0 ->
+            let (body, closed, rest1) = takePlaceholderBody rest0
+            in case closed of
+                False ->
+                    Left $ MalformedTemplate ln col
+                        (MalformedPlaceholder (T.pack body))
+
+                True
+                    | null body || not (all validPlaceholderChar body) ->
+                        Left $ MalformedTemplate ln col
+                            (MalformedPlaceholder (T.pack body))
+
+                    | otherwise ->
+                        let (ln', col') = advancePos ("{{" ++ body ++ "}}") ln col
+                        in go (makeVar body : tokens) rest1 ln' col'
+
+        _ ->
+            let (chunk, rest1) = takeChunk input
+                tokens' =
+                    if null chunk
+                        then tokens
+                        else makeChunk chunk : tokens
+                (ln', col') = advancePos chunk ln col
+            in go tokens' rest1 ln' col'
+
+    -- Consume ordinary text until the next "{{" or end of input.
+    takeChunk :: [Char] -> ([Char], [Char])
+    takeChunk xs = case xs of
+        [] -> ([], [])
+        '{':'{':_ -> ([], xs)
+        c:rest ->
+            let (chunk, rest') = takeChunk rest
+            in (c : chunk, rest')
+
+    -- Consume placeholder contents after seeing "{{".
+    -- Returns:
+    --   (body, foundClosingDelim, restAfterClosing)
+    takePlaceholderBody :: [Char] -> ([Char], Bool, [Char])
+    takePlaceholderBody xs = case xs of
+        [] -> ([], False, [])
+        '}':'}':rest -> ([], True, rest)
+        c:rest ->
+            let (body, closed, rest') = takePlaceholderBody rest
+            in (c : body, closed, rest')
+
+    advancePos :: [Char] -> Line -> Col -> (Line, Col)
+    advancePos cs ln col = foldl step (ln, col) cs
+      where
+        step :: (Line, Col) -> Char -> (Line, Col)
+        step (l, c) ch = case ch of
+            '\n' -> (l + 1, 0)
+            _    -> (l, c + 1)
 
 
 
@@ -67,12 +210,12 @@ loadTemplate spec = do
 defaultTemplateText :: Template
 defaultTemplateText = Template $ T.pack $ unlines
     [ "Preliminaries:"
-    , "{docs}"
+    , "{{docs}}"
     , "--------------------------------------------------------------------"
     , "You are a typed-hole plugin within GHC, the Glasgow Haskell Compiler."
     , "You are given a hole in a Haskell program, and you need to fill it in."
     , "The hole is represented by the following JSON encoded information:"
-    , "{context}"
+    , "{{context}}"
     , "Provide one or more Haskell expressions that could fill this hole."
     , "This means coming up with an expression of the correct type that satisfies the constraints."
     , "Pay special attention to the type of the hole, specifically whether it is a function."
@@ -81,5 +224,5 @@ defaultTemplateText = Template $ T.pack $ unlines
     , "Do not try to bind the hole variable, e.g. `_b = ...`. Produce only the expression."
     , "Do not include explanations, introductions, or any surrounding text."
     , "If you are using a function from scope, make sure to use the qualified name from the list of things in scope."
-    , "Output a maximum of {numexpr} expressions."
+    , "Output a maximum of {{numexpr}} expressions."
     ]

--- a/src/GHC/Plugin/OllamaHoles/Template.hs
+++ b/src/GHC/Plugin/OllamaHoles/Template.hs
@@ -2,22 +2,22 @@
 
 module GHC.Plugin.OllamaHoles.Template
     ( Template(..)
+    , TemplateExpr(..)
+    , Placeholder(..)
     , TemplateSpec(..)
     , TemplateSource(..)
     , TemplateError(..)
-    , TemplateExpr(..)
-    , Placeholder(..)
     , TemplateParseError(..)
     , mkTemplateEnv
     , loadTemplate
     , parseTemplate
     , expandTemplate
-    , expandTemplateExprs
     ) where
 
 import Data.Char (isAlpha, isAscii)
 import Data.Map (Map)
 import Data.Map qualified as M
+import Data.String (IsString(..))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
@@ -26,69 +26,32 @@ import System.FilePath ((</>))
 
 
 
--- Loading
-----------
+-- Templates
+------------
 
-newtype Template = Template Text
+newtype Template
+    = Template [TemplateExpr]
     deriving (Eq, Show)
 
--- | Runtime specification for selecting a template.
-data TemplateSpec = TemplateSpec
-    { tsSearchDir :: FilePath       -- where to look
-    , tsSource    :: TemplateSource -- how to look
-    } deriving (Eq, Show)
-
-data TemplateSource
-    = DefaultTemplate       -- Used if the spec is not specified
-    | TemplateFile FilePath -- When using a specific template by path
-    | NamedTemplate Text    -- When using a template by name in @tsSearchDir@
+data TemplateExpr
+    = TemplateChunk Text
+    | TemplateVar Placeholder
     deriving (Eq, Show)
 
-data TemplateError
-    = TemplateFileNotFound FilePath
-    | UnknownTemplateName FilePath Text
-    | UnknownPlaceholders [Placeholder]
-    | MalformedTemplate Line Col TemplateParseError
-    deriving (Eq, Show)
+newtype Placeholder
+    = Placeholder Text
+    deriving (Eq, Ord)
 
-loadTemplate :: TemplateSpec -> IO (Either TemplateError Template)
-loadTemplate spec = do
-    let TemplateSpec
-          { tsSearchDir = searchDir
-          , tsSource = source
-          } = spec
-    case source of
-        DefaultTemplate ->
-            pure (Right defaultTemplateText)
+instance IsString Placeholder where
+    fromString = Placeholder . fromString
 
-        TemplateFile path -> do
-            exists <- doesFileExist path
-            if exists
-                then fmap (Right . Template) $ T.readFile path
-                else pure $ Left $ TemplateFileNotFound path
-
-        NamedTemplate name -> do
-            let path = searchDir </> T.unpack name <> ".txt"
-            exists <- doesFileExist path
-            if exists
-                then fmap (Right . Template) $ T.readFile path
-                else pure (Left (UnknownTemplateName searchDir name))
+instance Show Placeholder where
+    show (Placeholder txt) = T.unpack txt
 
 
 
 -- Substitution
 ---------------
-
--- | Template variables are strings of ascii letters.
--- They occur in the template by name wrapped in
--- {{double_braces}}, but the braces are not part
--- of the name.
-newtype Placeholder
-    = Placeholder Text
-    deriving (Eq, Ord)
-
-instance Show Placeholder where
-    show (Placeholder txt) = T.unpack txt
 
 data TemplateEnv
     = TemplateEnv (Map Placeholder Text)
@@ -96,28 +59,24 @@ data TemplateEnv
 
 mkTemplateEnv :: [(Text, Text)] -> TemplateEnv
 mkTemplateEnv = TemplateEnv . M.fromList .
-  fmap (\(k,v) -> (Placeholder k, v))
+    fmap (\(k,v) -> (Placeholder k, v))
 
 lookupPlaceholder
     :: TemplateEnv -> Placeholder -> Either Placeholder Text
 lookupPlaceholder (TemplateEnv m) name =
     maybe (Left name) Right (M.lookup name m)
 
-data TemplateExpr
-    = TemplateChunk Text
-    | TemplateVar Placeholder
-    deriving (Eq, Show)
-
-expandTemplateExpr
-    :: TemplateEnv -> TemplateExpr -> Either Placeholder Text
-expandTemplateExpr env expr = case expr of
-    TemplateChunk txt -> Right txt
-    TemplateVar var -> lookupPlaceholder env var
-
-expandTemplateExprs
-    :: TemplateEnv -> [TemplateExpr] -> Either TemplateError Text
-expandTemplateExprs env =
-    collectEithers UnknownPlaceholders mconcat . fmap (expandTemplateExpr env)
+expandTemplate
+  :: TemplateEnv -> Template -> Either TemplateError Text
+expandTemplate env (Template exprs) = do
+    collectEithers UnknownPlaceholders mconcat $
+        fmap (expandTemplateExpr env) exprs
+    where
+        expandTemplateExpr
+            :: TemplateEnv -> TemplateExpr -> Either Placeholder Text
+        expandTemplateExpr env expr = case expr of
+            TemplateChunk txt -> Right txt
+            TemplateVar var -> lookupPlaceholder env var
 
 collectEithers
     :: forall a b u v. ([a] -> u) -> ([b] -> v) -> [Either a b] -> Either u v
@@ -132,16 +91,15 @@ collectEithers f g = go [] []
                 Left  a -> go (a:as) bs rest
                 Right b -> go as (b:bs) rest
 
-expandTemplate
-  :: TemplateEnv -> Template -> Either TemplateError Text
-expandTemplate env template = do
-    parseTemplate template >>= expandTemplateExprs env
-
-
 
 
 -- Parsing
 ----------
+
+-- | Template variables are strings of ascii letters.
+-- They occur in the template by name wrapped in
+-- {{double_braces}}, but the braces are not part
+-- of the name.
 
 type Line = Int
 type Col  = Int
@@ -151,8 +109,8 @@ data TemplateParseError
     deriving (Eq, Ord, Show)
 
 parseTemplate
-    :: Template -> Either TemplateError [TemplateExpr]
-parseTemplate (Template raw) = go [] (T.unpack raw) 0 0
+    :: Text -> Either TemplateError Template
+parseTemplate raw = fmap Template $ go [] (T.unpack raw) 0 0
   where
     makeChunk, makeVar :: [Char] -> TemplateExpr
     makeChunk = TemplateChunk . T.pack
@@ -222,11 +180,66 @@ parseTemplate (Template raw) = go [] (T.unpack raw) 0 0
 
 
 
+
+
+
+-- Loading
+----------
+
+-- | Runtime specification for selecting a template.
+data TemplateSpec = TemplateSpec
+    { tsSearchDir :: FilePath       -- where to look
+    , tsSource    :: TemplateSource -- how to look
+    } deriving (Eq, Show)
+
+data TemplateSource
+    = DefaultTemplate       -- Used if the spec is not specified
+    | TemplateFile FilePath -- When using a specific template by path
+    | NamedTemplate Text    -- When using a template by name in @tsSearchDir@
+    deriving (Eq, Show)
+
+loadTemplate :: TemplateSpec -> IO (Either TemplateError Template)
+loadTemplate spec = do
+    let TemplateSpec
+          { tsSearchDir = searchDir
+          , tsSource = source
+          } = spec
+    case source of
+        DefaultTemplate ->
+            pure (parseTemplate defaultTemplateText)
+
+        TemplateFile path -> do
+            exists <- doesFileExist path
+            if exists
+                then fmap parseTemplate $ T.readFile path
+                else pure $ Left $ TemplateFileNotFound path
+
+        NamedTemplate name -> do
+            let path = searchDir </> T.unpack name <> ".txt"
+            exists <- doesFileExist path
+            if exists
+                then fmap parseTemplate $ T.readFile path
+                else pure (Left (UnknownTemplateName searchDir name))
+
+
+
+-- Errors
+---------
+
+data TemplateError
+    = TemplateFileNotFound FilePath
+    | UnknownTemplateName FilePath Text
+    | UnknownPlaceholders [Placeholder]
+    | MalformedTemplate Line Col TemplateParseError
+    deriving (Eq, Show)
+
+
+
 -- Default Template
 -------------------
 
-defaultTemplateText :: Template
-defaultTemplateText = Template $ T.pack $ unlines
+defaultTemplateText :: Text
+defaultTemplateText = T.pack $ unlines
     [ "Preliminaries:"
     , "{{docs}}"
     , "--------------------------------------------------------------------"

--- a/src/GHC/Plugin/OllamaHoles/Template.hs
+++ b/src/GHC/Plugin/OllamaHoles/Template.hs
@@ -1,0 +1,85 @@
+module GHC.Plugin.OllamaHoles.Template
+    ( Template(..)
+    , TemplateSpec(..)
+    , TemplateSource(..)
+    , TemplateError(..)
+    , loadTemplate
+    ) where
+
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
+import System.Directory (doesFileExist)
+
+
+
+-- Loading
+----------
+
+newtype Template = Template Text
+    deriving (Eq, Show)
+
+-- | Runtime specification for selecting a template.
+data TemplateSpec = TemplateSpec
+    { tsSearchDir :: FilePath       -- where to look
+    , tsSource    :: TemplateSource -- how to look
+    } deriving (Eq, Show)
+
+data TemplateSource
+    = DefaultTemplate       -- Used if the spec is missing or malformed
+    | TemplateFile FilePath -- When using a specific template by path
+    | NamedTemplate Text    -- When using a template by name in @tsSearchDir@
+    deriving (Eq, Show)
+
+data TemplateError
+    = TemplateFileNotFound FilePath
+    | UnknownTemplateName FilePath Text
+    deriving (Eq, Show)
+
+loadTemplate :: TemplateSpec -> IO (Either TemplateError Template)
+loadTemplate spec = do
+    let TemplateSpec
+          { tsSearchDir = searchDir
+          , tsSource = source
+          } = spec
+    case source of
+        DefaultTemplate ->
+            pure (Right defaultTemplateText)
+
+        TemplateFile path -> do
+            exists <- doesFileExist path
+            if exists
+                then fmap (Right . Template) $ T.readFile path
+                else pure $ Left $ TemplateFileNotFound path
+
+        NamedTemplate name -> do
+            let path = searchDir <> "/" <> T.unpack name <> ".txt"
+            exists <- doesFileExist path
+            if exists
+                then fmap (Right . Template) $ T.readFile path
+                else pure (Left (UnknownTemplateName searchDir name))
+
+
+
+-- Default Template
+-------------------
+
+defaultTemplateText :: Template
+defaultTemplateText = Template $ T.pack $ unlines
+    [ "Preliminaries:"
+    , "{docs}"
+    , "--------------------------------------------------------------------"
+    , "You are a typed-hole plugin within GHC, the Glasgow Haskell Compiler."
+    , "You are given a hole in a Haskell program, and you need to fill it in."
+    , "The hole is represented by the following JSON encoded information:"
+    , "{context}"
+    , "Provide one or more Haskell expressions that could fill this hole."
+    , "This means coming up with an expression of the correct type that satisfies the constraints."
+    , "Pay special attention to the type of the hole, specifically whether it is a function."
+    , "Make sure you synthesize an expression that matches the type of the hole."
+    , "Output ONLY the raw Haskell expression(s), one per line."
+    , "Do not try to bind the hole variable, e.g. `_b = ...`. Produce only the expression."
+    , "Do not include explanations, introductions, or any surrounding text."
+    , "If you are using a function from scope, make sure to use the qualified name from the list of things in scope."
+    , "Output a maximum of {numexpr} expressions."
+    ]

--- a/src/GHC/Plugin/OllamaHoles/Template.hs
+++ b/src/GHC/Plugin/OllamaHoles/Template.hs
@@ -6,15 +6,19 @@ module GHC.Plugin.OllamaHoles.Template
     , Placeholder(..)
     , TemplateSpec(..)
     , TemplateSource(..)
+    , TemplateName()
+    , parseTemplateName
     , TemplateError(..)
     , TemplateParseError(..)
     , mkTemplateEnv
     , loadTemplate
     , parseTemplate
     , expandTemplate
+    --
+    , unsafeCreateRawTemplateName
     ) where
 
-import Data.Char (isAlpha, isAscii)
+import Data.Char (isAlpha, isAscii, isAlphaNum)
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.String (IsString(..))
@@ -193,10 +197,27 @@ data TemplateSpec = TemplateSpec
     } deriving (Eq, Show)
 
 data TemplateSource
-    = DefaultTemplate       -- Used if the spec is not specified
-    | TemplateFile FilePath -- When using a specific template by path
-    | NamedTemplate Text    -- When using a template by name in @tsSearchDir@
+    = DefaultTemplate            -- Used if the spec is not specified
+    | TemplateFile FilePath      -- When using a specific template by path
+    | NamedTemplate TemplateName -- When using a template by name in @tsSearchDir@
     deriving (Eq, Show)
+
+newtype TemplateName
+    = TemplateName Text
+    deriving (Eq, Show)
+
+-- For tests
+unsafeCreateRawTemplateName :: Text -> TemplateName
+unsafeCreateRawTemplateName = TemplateName
+
+-- This is spliced into a string and read as a filename;
+-- restricting to alphanumerics, -, and _ avoids malicious
+-- names like ".." or "foo\bar".
+parseTemplateName :: Text -> TemplateName
+parseTemplateName = TemplateName . T.filter nameSafeChar
+
+nameSafeChar :: Char -> Bool
+nameSafeChar c = isAlphaNum c || c == '-' || c == '_'
 
 loadTemplate :: TemplateSpec -> IO (Either TemplateError Template)
 loadTemplate spec = do
@@ -214,12 +235,15 @@ loadTemplate spec = do
                 then fmap parseTemplate $ T.readFile path
                 else pure $ Left $ TemplateFileNotFound path
 
-        NamedTemplate name -> do
-            let path = searchDir </> T.unpack name <> ".txt"
-            exists <- doesFileExist path
-            if exists
-                then fmap parseTemplate $ T.readFile path
-                else pure (Left (UnknownTemplateName searchDir name))
+        NamedTemplate (TemplateName name) -> do
+            if T.any (not . nameSafeChar) name || T.null name
+                then pure (Left $ InvalidTemplateName name)
+                else do
+                    let path = searchDir </> T.unpack name <> ".txt"
+                    exists <- doesFileExist path
+                    if exists
+                        then fmap parseTemplate $ T.readFile path
+                        else pure (Left (UnknownTemplateName searchDir name))
 
 
 
@@ -231,6 +255,7 @@ data TemplateError
     | UnknownTemplateName FilePath Text
     | UnknownPlaceholders [Placeholder]
     | MalformedTemplate Line Col TemplateParseError
+    | InvalidTemplateName Text
     deriving (Eq, Show)
 
 

--- a/src/GHC/Plugin/OllamaHoles/Template.hs
+++ b/src/GHC/Plugin/OllamaHoles/Template.hs
@@ -213,8 +213,11 @@ unsafeCreateRawTemplateName = TemplateName
 -- This is spliced into a string and read as a filename;
 -- restricting to alphanumerics, -, and _ avoids malicious
 -- names like ".." or "foo\bar".
-parseTemplateName :: Text -> TemplateName
-parseTemplateName = TemplateName . T.filter nameSafeChar
+parseTemplateName :: Text -> Either TemplateError TemplateName
+parseTemplateName t
+  | T.null t = Left (InvalidTemplateName t)
+  | T.all nameSafeChar t = Right (TemplateName t)
+  | otherwise = Left (InvalidTemplateName t)
 
 nameSafeChar :: Char -> Bool
 nameSafeChar c = isAlphaNum c || c == '-' || c == '_'

--- a/src/GHC/Plugin/OllamaHoles/Template.hs
+++ b/src/GHC/Plugin/OllamaHoles/Template.hs
@@ -8,8 +8,11 @@ module GHC.Plugin.OllamaHoles.Template
     , TemplateExpr(..)
     , Placeholder(..)
     , TemplateParseError(..)
+    , mkTemplateEnv
     , loadTemplate
     , parseTemplate
+    , expandTemplate
+    , expandTemplateExprs
     ) where
 
 import Data.Char (isAlpha, isAscii)
@@ -91,6 +94,10 @@ data TemplateEnv
     = TemplateEnv (Map Placeholder Text)
     deriving (Eq, Show)
 
+mkTemplateEnv :: [(Text, Text)] -> TemplateEnv
+mkTemplateEnv = TemplateEnv . M.fromList .
+  fmap (\(k,v) -> (Placeholder k, v))
+
 lookupPlaceholder
     :: TemplateEnv -> Placeholder -> Either Placeholder Text
 lookupPlaceholder (TemplateEnv m) name =
@@ -124,6 +131,17 @@ collectEithers f g = go [] []
             x:rest -> case x of
                 Left  a -> go (a:as) bs rest
                 Right b -> go as (b:bs) rest
+
+expandTemplate
+  :: TemplateEnv -> Template -> Either TemplateError Text
+expandTemplate env template = do
+    parseTemplate template >>= expandTemplateExprs env
+
+
+
+
+-- Parsing
+----------
 
 type Line = Int
 type Col  = Int


### PR DESCRIPTION
Right now the prompt is constructed from a template built into the plugin. This makes iterating on the prompt awkward.

This patch adds a very basic template function that supports reading the template from a file specified on the command line and substituting a few built in `{{variables}}`.