### PR TITLE
Catch errors with ExceptT

### DIFF
--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -158,7 +158,8 @@ library
                       crypton >= 1.1.2,
                       bytestring >= 0.12.2,
                       directory >= 1.3.10.1,
-                      mtl >= 2.3
+                      mtl >= 2.3,
+                      transformers >= 0.6.3
 
     -- Directories containing source files.
     hs-source-dirs:   src

--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -157,7 +157,8 @@ library
                       time >= 1.14,
                       crypton >= 1.1.2,
                       bytestring >= 0.12.2,
-                      directory >= 1.3.10.1
+                      directory >= 1.3.10.1,
+                      mtl >= 2.3
 
     -- Directories containing source files.
     hs-source-dirs:   src

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -8,7 +8,7 @@
 module GHC.Plugin.OllamaHoles where
 
 import Control.Monad (unless, when, forM_)
-import Data.Aeson
+import Control.Monad.Except (ExceptT, runExceptT, MonadError(..))
 import Data.Char (isSpace)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -50,7 +50,6 @@ import GHC.Iface.Load qualified as GHC (loadInterfaceForName)
 import GHC.Tc.Utils.TcType qualified as GHC (tyCoFVsOfType, mkPhiTy)
 import GHC.Tc.Solver qualified as GHC (simplifyTop, simplifyInfer, captureTopConstraints, InferMode(..))
 import GHC.Tc.Solver.Monad qualified as GHC (zonkTcType, runTcSEarlyAbort)
-import Data.Aeson qualified as Aeson
 
 import GHC.Plugin.OllamaHoles.Options
 import GHC.Plugin.OllamaHoles.Prompt
@@ -92,6 +91,36 @@ setCandidates :: [HoleFitCandidate] -> PluginState -> PluginState
 setCandidates cs st = st { candidates = cs }
 
 -- | Initialize the plugin state
+tryPluginInitLLM
+  :: [CommandLineOption] -> ExceptT PluginInitError TcM (TcRef PluginState)
+tryPluginInitLLM opts = do
+  let optParseResult = parseCommandLineOptions defaultFlags opts
+  flags <- case optParseResult of
+    Left err -> throwError $ OptionParseError err
+    Right (fs, unk) -> do
+      when (not $ null unk) $ do
+        throwError $ UnknownOptionError unk
+      pure fs
+  spec <- case mkTemplateSpec flags of
+    Left err -> throwError $ TemplateSpecError err
+    Right ok -> pure ok
+  logger <- liftIO $ Log.initLogger (log_mode flags) (log_dir flags)
+  template <- do
+    raw <- liftIO $ loadTemplate spec
+    case raw of
+      Left err -> throwError $ TemplateParseError err
+      Right ok -> pure ok
+  newTcRef $ PluginState
+    { candidates     = []
+    , writeLogEvent  = logger
+    , templateSpec   = spec
+    , parsedTemplate = template
+    , commandOptions = flags
+    }
+
+
+{-
+-- | Initialize the plugin state
 hfPluginInitLLM :: [CommandLineOption] -> TcM (TcRef PluginState)
 hfPluginInitLLM opts = do
   let optParseResult = parseCommandLineOptions defaultFlags opts
@@ -117,6 +146,15 @@ hfPluginInitLLM opts = do
     , parsedTemplate = template
     , commandOptions = flags
     }
+-}
+
+data PluginInitError
+    = OptionParseError OptError
+    | UnknownOptionError [Token]
+    | TemplateSpecError TemplateError
+    | TemplateParseError TemplateError
+    deriving (Eq, Show)
+
 
 
 

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -113,8 +113,12 @@ data PluginError
 
 isSilentError :: PluginError -> Bool
 isSilentError = \case
-  TypedHoleNotFound _ -> True
-  _                   -> False
+  OptionParseError   _ -> True -- \
+  UnknownOptionError _ -> True --  | These are initialization errors, and
+  TemplateSpecError  _ -> True --  | are printed by printRenderedError.
+  TemplateParseError _ -> True -- /
+  TypedHoleNotFound  _ -> True -- This just means there are no typed holes.
+  _                    -> False
 
 renderPluginError :: PluginError -> Text
 renderPluginError = \case
@@ -172,7 +176,8 @@ hfPluginInitLLM
   :: [CommandLineOption]
   -> TcM (TcRef (Either PluginError PluginState))
 hfPluginInitLLM =
-  (liftIO . runExceptT . tryPluginInitLLM) >=> newTcRef
+  (liftIO . runExceptT . tryPluginInitLLM)
+    >=> printRenderedError >=> newTcRef
 
 -- | Initialize the plugin state
 tryPluginInitLLM
@@ -508,3 +513,11 @@ debugMsg st txt = liftIO $ when (debug $ commandOptions st) $
 
 liftEitherIO :: (MonadIO m) => (e1 -> e2) -> IO (Either e1 a) -> ExceptT e2 m a
 liftEitherIO f act = liftIO act >>= either (throwError . f) pure
+
+printRenderedError
+  :: (MonadIO m) => Either PluginError u -> m (Either PluginError u)
+printRenderedError x = case x of
+  Right u -> pure (Right u)
+  Left err -> do
+    liftIO $ T.putStrLn $ renderPluginError err
+    pure (Left err)

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE LambdaCase #-}
 
 -- | The Ollama plugin for GHC
 module GHC.Plugin.OllamaHoles where
@@ -12,7 +13,6 @@ import Control.Monad.Except (ExceptT, runExceptT, MonadError(..), liftEither)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.Class (MonadTrans(..))
 import Control.Monad.Trans.Except ()
-import Data.Aeson (Value)
 import Data.Char (isSpace)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -69,6 +69,9 @@ plugin = defaultPlugin
   { holeFitPlugin = Just . mkHoleFitPluginR
   }
 
+pluginName :: Text
+pluginName = "Ollama Plugin"
+
 mkHoleFitPluginR
   :: [CommandLineOption] -> HoleFitPluginR
 mkHoleFitPluginR opts = HoleFitPluginR
@@ -82,6 +85,8 @@ mkHoleFitPluginR opts = HoleFitPluginR
     }
   }
 
+
+
 -- State
 --------
 
@@ -92,6 +97,9 @@ data PluginState = PluginState
   , parsedTemplate :: Template
   , commandOptions :: Flags
   }
+
+setCandidates :: [HoleFitCandidate] -> PluginState -> PluginState
+setCandidates cs st = st { candidates = cs }
 
 data PluginError
   = OptionParseError OptError
@@ -106,9 +114,12 @@ data PluginError
   -- deriving (Eq, Show)
 
 renderPluginError :: PluginError -> Text
-renderPluginError err = case err of
+renderPluginError = \case
+  OptionParseError err -> mconcat
+    [ "Option parse error: ", T.pack (show err)
+    ]
   ModelNotFound modelName models backendName -> mconcat
-    [ pluginName, ": Model ", modelName, " not found. "
+    [ "Model ", modelName, " not found. "
     , if backendName == "ollama"
         then "Use `ollama pull` to download the model, or " else ""
     , "specify another model using "
@@ -119,10 +130,10 @@ renderPluginError err = case err of
     [ pluginName, ": ERROR - " --, T.pack (show err)
     ]
 
-setCandidates :: [HoleFitCandidate] -> PluginState -> PluginState
-setCandidates cs st = st { candidates = cs }
 
 
+-- Initialize
+-------------
 
 hfPluginInitLLM
   :: [CommandLineOption]
@@ -149,24 +160,10 @@ tryPluginInitLLM opts = do
     , commandOptions = flags
     }
 
-onLeftIO :: (MonadIO m) => (e1 -> e2) -> IO (Either e1 a) -> ExceptT e2 m a
-onLeftIO f act = liftIO act >>= either (throwError . f) pure
 
 
-
--- | Determine which backend to use
-getBackend :: Flags -> Backend
-getBackend Flags{backend_name = "ollama"} = ollamaBackend
-getBackend Flags{backend_name = "gemini"} = geminiBackend
-getBackend Flags{backend_name = "openai", ..} = openAICompatibleBackend openai_base_url openai_key_name
-getBackend Flags{..} = error $ "unknown backend: " <> T.unpack backend_name
-
-
-
-pluginName :: Text
-pluginName = "Ollama Plugin"
-
-
+-- Fit Holes
+------------
 
 fitPluginLLM
   :: TcRef (Either PluginError PluginState)
@@ -182,30 +179,25 @@ fitPluginLLM ref hole fits = do
       pure fits
 
 tryFitPluginLLM
-    :: TcRef (Either PluginError PluginState)
-    -> TypedHole
-    -> [HoleFit] -- Known hole fits from GHC
-    -> ExceptT PluginError TcM [HoleFit]
+  :: TcRef (Either PluginError PluginState)
+  -> TypedHole
+  -> [HoleFit] -- Known hole fits from GHC
+  -> ExceptT PluginError TcM [HoleFit]
 tryFitPluginLLM ref typedHole fits = do
-    PluginState cands logger templateSpec template flags <- readTcRef ref >>= liftEither
-    dflags <- getDynFlags
-    let debugMode = debug flags
-    liftIO $ when debugMode $ T.putStrLn $ "Running " <> pluginName <> " with flags:"
-    liftIO $ when debugMode $ print flags
-
-    checkModel flags
-
-    liftIO $ when debugMode $ T.putStrLn $ pluginName <> ": Hole Found"
-
-    h <- atHole typedHole
-    prompt <- prepareHoleFitPrompt dflags flags typedHole fits cands template
-    liftIO $ when debugMode $ do T.putStrLn $ "NEW PROMPT:\n\n" <> prompt <> "\n\n"
-    rsp <- submitRequest flags prompt
-    lift $ extractHoleFitsFromResponse dflags prompt rsp logger typedHole h debugMode
+  st <- readTcRef ref >>= liftEither
+  debugMsg st $ "running with flags\n" <> T.pack (show $ commandOptions st)
+  checkModel st
+  debugMsg st "Hole Found"
+  withTypedHole typedHole $ \hole -> do
+    prompt <- prepareHoleFitPrompt st typedHole fits
+    debugMsg st $ "prompt:\n" <> prompt
+    rsp <- submitRequest st prompt
+    lift $ extractHoleFitsFromResponse st prompt rsp typedHole hole
 
 -- | Ensure that the specified model exists.
-checkModel :: Flags -> ExceptT PluginError TcM ()
-checkModel flags = do
+checkModel :: PluginState -> ExceptT PluginError TcM ()
+checkModel st = do
+  let flags = commandOptions st
   let backend = getBackend flags
   available_models <- liftIO $ listModels backend
   case available_models of
@@ -215,87 +207,109 @@ checkModel flags = do
 
 -- | Build a prompt for the LLM from context.
 prepareHoleFitPrompt
-  :: DynFlags -> Flags -> TypedHole
+  :: PluginState -> TypedHole
   -> [HoleFit]          -- Known hole fits provided by GHC
-  -> [HoleFitCandidate] -- Not yet checked; used for getting guidance
-  -> Template -> ExceptT PluginError TcM Text
-prepareHoleFitPrompt dflags flags hole fits cands template = do
+  -> ExceptT PluginError TcM Text
+prepareHoleFitPrompt st hole fits = do
+  let flags = commandOptions st
   gbl_env <- lift getGblEnv
-  docs <- lift $ if include_docs flags then getDocs cands else return ""
-  onLeftIO TemplateSubError $ pure $ expandTemplateWith template $ mkTemplateEnv
-    [ ("backend" , backend_name flags)
-    , ("model"   , model_name flags)
-    , ("numexpr" , T.pack (show $ num_expr flags))
-    , ("docs"    , T.pack docs)
-    , ("context" , maybe "" encodePromptContext $
-                        getPromptContext hole fits gbl_env cands dflags)
-    ]
+  dflags <- lift getDynFlags
+  docs <- lift $ if include_docs flags
+    then getDocs (candidates st) else return ""
+  onLeftIO TemplateSubError $ pure $
+    expandTemplateWith (parsedTemplate st) $ mkTemplateEnv
+      [ ("backend" , backend_name flags)
+      , ("model"   , model_name flags)
+      , ("numexpr" , T.pack (show $ num_expr flags))
+      , ("docs"    , T.pack docs)
+      , ("context" , maybe "" encodePromptContext $
+                      getPromptContext hole fits gbl_env (candidates st) dflags)
+      ]
 
-atHole
-  :: TypedHole -> ExceptT PluginError TcM Hole
-atHole hole = case th_hole hole of
-  Just ok -> pure ok
+withTypedHole
+  :: TypedHole -> (Hole -> ExceptT PluginError TcM a)
+  -> ExceptT PluginError TcM a
+withTypedHole hole act = case th_hole hole of
   Nothing -> throwError $ TypedHoleNotFound hole
+  Just ok -> act ok
 
 submitRequest
-  :: Flags -> Log.Prompt
+  :: PluginState -> Log.Prompt
   -> ExceptT PluginError TcM Text
-submitRequest flags prompt = do
+submitRequest st prompt = do
+  let flags = commandOptions st
   let backend = getBackend flags
-  res <- liftIO $ generateFits backend prompt (model_name flags) (model_options flags)
+  res <- liftIO $ generateFits
+    backend prompt (model_name flags) (model_options flags)
   case res of
     Right rsp -> pure rsp
     Left err -> throwError $ ResponseFailed $ T.pack err
 
 extractHoleFitsFromResponse
-    :: DynFlags -> Log.Prompt -> Log.Response -> Log.Logger
-    -> TypedHole -> Hole -> Bool -> TcM [HoleFit]
-extractHoleFitsFromResponse dflags prompt' rsp logger hole h debug = do
-    let rawLines      = preProcess (T.lines rsp) -- raw candidate list
-    let surfaceUnique = L.nub rawLines           -- remove syntactic duplicates
+  :: PluginState -> Log.Prompt -> Log.Response
+  -> TypedHole -> Hole -> TcM [HoleFit]
+extractHoleFitsFromResponse st prompt rsp hole h = do
+  let logger = writeLogEvent st
+  let debugMode = debug (commandOptions st)
+  dflags <- getDynFlags
 
-    liftIO $ when debug $ do
-        putStrLn "--- raw candidates ---"
-        mapM_ T.putStrLn rawLines
-        putStrLn ""
-        putStrLn "--- syntactic uniques ---"
-        mapM_ T.putStrLn surfaceUnique
-        putStrLn ""
+  -- Get the raw list of candidates
+  let rawLines = preProcess (T.lines rsp)
+  when (not $ null rawLines) $ do
+    let numRaw = T.pack $ show $ length rawLines
+    debugMsg st $ "--- raw candidates (" <> numRaw <> ") ---\n"
+      <> T.unlines rawLines
 
-    -- prepare candidates for semantic deduplication
-    preparedE <- traverse
-        (pipelineCandidate (mkParseCtx dflags) (mkRenameCtx debug)
-          (mkCheckCtx debug hole) (mkPrepCtx dflags (holeArity h)))
-        surfaceUnique
+  -- Remove syntactic duplicates
+  let surfaceUnique = L.nub rawLines
+  when (not $ null surfaceUnique) $ do
+    let numSurf = T.pack $ show $ length surfaceUnique
+    debugMsg st $ "--- syntactic uniques (" <> numSurf <> ") ---\n"
+      <> T.unlines surfaceUnique
 
-    -- check that we reach the same conclusion as
-    -- the original fit check
-    when debug $ regressionCheck hole surfaceUnique preparedE
+  -- prepare candidates for semantic deduplication
+  preparedE <- for surfaceUnique
+    (pipelineCandidate (mkParseCtx dflags) (mkRenameCtx debugMode)
+      (mkCheckCtx debugMode hole) (mkPrepCtx dflags (holeArity h)))
 
-    let failures = [ (src, err) | (src, Left err) <- zip surfaceUnique preparedE ]
-    let prepared = [ pc | Right pc <- preparedE ]
-    let deduped  = dedupePreparedCandidates prepared
-    let holeFits = map (RawHoleFit . text . T.unpack . prSource) deduped
+  -- check that we reach the same conclusion as
+  -- the original fit check
+  regressionCheck hole surfaceUnique preparedE
 
-    liftIO $ when debug $ do
-        when (not $ null failures) $ do
-            putStrLn "--- candidate validation failures ---"
-            mapM_ (putStrLn . uncurry renderCandidateError) failures
-            putStrLn ""
-        putStrLn "--- prepared for semantic-ish deduplication ---"
-        forM_ prepared $ \pc -> do
-            putStrLn ("source: " <> T.unpack (prSource pc))
-            putStrLn ("rank:   " <> show (prRank pc))
-            putStrLn ("key:    " <> show (prNormKey pc))
-            putStrLn ""
-        putStrLn "--- semantic-ish uniques ---"
-        mapM_ (putStrLn . T.unpack . prSource) deduped
-        putStrLn ""
+  -- Report any validation errors
+  let failures = [ (src, err) | (src, Left err) <- zip surfaceUnique preparedE ]
+  when (not $ null failures) $ do
+    let numFail = T.pack $ show $ length failures
+    debugMsg st $ "--- candidate validation failures (" <> numFail <> ") ---\n"
+      <> T.unlines (fmap (uncurry renderCandidateError) failures)
 
-    liftIO $ Log.writeLogEvent logger $ Log.mkLogEvent
-        prompt' rsp (length rawLines) (length deduped) (length prepared)
+  -- Normalize expressions for deduplication
+  let prepared = [ pc | Right pc <- preparedE ]
+  when (not $ null prepared) $ do
+    let numPrep = T.pack $ show $ length prepared
+    debugMsg st $ "--- prepared for semantic-ish deduplication (" <> numPrep <> ") ---\n"
+      <> T.intercalate "\n" (foldMapFor prepared $ \pc -> (:[]) $ T.unlines
+        [ "source: " <> prSource pc
+        , "rank:   " <> T.pack (show $ prRank pc)
+        , "key:    " <> T.pack (show $ prNormKey pc)
+        ])
 
-    return holeFits
+  -- Deduplicate expressions
+  let deduped  = dedupePreparedCandidates prepared
+  when (not $ null deduped) $ do
+    let numUniq = T.pack $ show $ length deduped
+    debugMsg st $ "--- semantic-ish uniques (" <> numUniq <> ") ---\n"
+      <> T.unlines (fmap prSource deduped)
+
+  liftIO $ Log.writeLogEvent logger $ Log.mkLogEvent
+      prompt rsp (length rawLines) (length deduped) (length prepared)
+
+  let holeFits = map (RawHoleFit . text . T.unpack . prSource) deduped
+  return holeFits
+
+
+
+
 
 holeArity :: Hole -> Int
 holeArity = length . fst . splitFunTys . hole_ty
@@ -442,3 +456,24 @@ mkTemplateSpec Flags{..} = do
         (_, Just nm) -> fmap (mkSpec . NamedTemplate) $ parseTemplateName nm
         _            -> Right $ mkSpec $ DefaultTemplate
 
+-- | Determine which backend to use
+getBackend :: Flags -> Backend
+getBackend Flags{backend_name = "ollama"} = ollamaBackend
+getBackend Flags{backend_name = "gemini"} = geminiBackend
+getBackend Flags{backend_name = "openai", ..} = openAICompatibleBackend openai_base_url openai_key_name
+getBackend Flags{..} = error $ "unknown backend: " <> T.unpack backend_name -- TODO
+
+
+
+-- Utils
+--------
+
+debugMsg :: (MonadIO m) => PluginState -> Text -> m ()
+debugMsg st txt = liftIO $ when (debug $ commandOptions st) $
+  T.putStrLn $ pluginName <> ": " <> txt
+
+onLeftIO :: (MonadIO m) => (e1 -> e2) -> IO (Either e1 a) -> ExceptT e2 m a
+onLeftIO f act = liftIO act >>= either (throwError . f) pure
+
+foldMapFor :: (Foldable t, Monoid m) => t a -> (a -> m) -> m
+foldMapFor = flip foldMap

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -7,8 +7,12 @@
 -- | The Ollama plugin for GHC
 module GHC.Plugin.OllamaHoles where
 
-import Control.Monad (unless, when, forM_)
+import Control.Monad (unless, when, forM_, (>=>))
 import Control.Monad.Except (ExceptT, runExceptT, MonadError(..))
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.Trans.Class (MonadTrans(..))
+import Control.Monad.Trans.Except ()
+import Data.Aeson (Value)
 import Data.Char (isSpace)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -68,10 +72,12 @@ plugin = defaultPlugin
 mkHoleFitPluginR
   :: [CommandLineOption] -> HoleFitPluginR
 mkHoleFitPluginR opts = HoleFitPluginR
-  { hfPluginInit = hfPluginInitLLM opts
+  { hfPluginInit =
+      -- Initialize the plugin (this may fail).
+      hfPluginInitLLM opts :: TcM (TcRef (Either PluginError PluginState))
   , hfPluginStop = \_ -> return ()
   , hfPluginRun = \ref -> HoleFitPlugin
-    { candPlugin = \_ cs -> updTcRef ref (setCandidates cs) >> return cs
+    { candPlugin = \_ cs -> updTcRef ref (fmap (setCandidates cs)) >> return cs
     , fitPlugin = fitPluginLLM ref
     }
   }
@@ -87,30 +93,55 @@ data PluginState = PluginState
   , commandOptions :: Flags
   }
 
+data PluginError
+  = OptionParseError OptError
+  | UnknownOptionError [Token]
+  | TemplateSpecError TemplateError
+  | TemplateParseError TemplateError
+  | TemplateSubError TemplateError
+  | NoModelsAvailable
+  | ModelNotFound Text [Text] Text
+  | TypedHoleNotFound TypedHole
+  | ResponseFailed Text
+  -- deriving (Eq, Show)
+
+renderPluginError :: PluginError -> Text
+renderPluginError err = case err of
+  ModelNotFound modelName models backendName -> mconcat
+    [ pluginName, ": Model ", modelName, " not found. "
+    , if backendName == "ollama"
+        then "Use `ollama pull` to download the model, or " else ""
+    , "specify another model using "
+    , "`-fplugin-opt=GHC.Plugin.OllamaHoles:model=<model_name>`\n"
+    , "Availble models: \n", T.unlines models
+    ]
+  _ -> mconcat
+    [ pluginName, ": ERROR - " --, T.pack (show err)
+    ]
+
 setCandidates :: [HoleFitCandidate] -> PluginState -> PluginState
 setCandidates cs st = st { candidates = cs }
 
+
+
+hfPluginInitLLM
+  :: [CommandLineOption]
+  -> TcM (TcRef (Either PluginError PluginState))
+hfPluginInitLLM =
+  (liftIO . runExceptT . tryPluginInitLLM) >=> newTcRef
+
 -- | Initialize the plugin state
 tryPluginInitLLM
-  :: [CommandLineOption] -> ExceptT PluginInitError TcM (TcRef PluginState)
+  :: [CommandLineOption] -> ExceptT PluginError IO PluginState
 tryPluginInitLLM opts = do
-  let optParseResult = parseCommandLineOptions defaultFlags opts
-  flags <- case optParseResult of
-    Left err -> throwError $ OptionParseError err
-    Right (fs, unk) -> do
-      when (not $ null unk) $ do
-        throwError $ UnknownOptionError unk
-      pure fs
-  spec <- case mkTemplateSpec flags of
-    Left err -> throwError $ TemplateSpecError err
-    Right ok -> pure ok
+  flags <- case parseCommandLineOptions defaultFlags opts of
+    Right (fs, []) -> pure fs
+    Right (_, unk) -> throwError $ UnknownOptionError unk
+    Left err       -> throwError $ OptionParseError err
+  spec <- onLeftIO TemplateSpecError $ pure $ mkTemplateSpec flags
   logger <- liftIO $ Log.initLogger (log_mode flags) (log_dir flags)
-  template <- do
-    raw <- liftIO $ loadTemplate spec
-    case raw of
-      Left err -> throwError $ TemplateParseError err
-      Right ok -> pure ok
-  newTcRef $ PluginState
+  template <- onLeftIO TemplateParseError $ loadTemplate spec
+  pure $ PluginState
     { candidates     = []
     , writeLogEvent  = logger
     , templateSpec   = spec
@@ -118,43 +149,8 @@ tryPluginInitLLM opts = do
     , commandOptions = flags
     }
 
-
-{-
--- | Initialize the plugin state
-hfPluginInitLLM :: [CommandLineOption] -> TcM (TcRef PluginState)
-hfPluginInitLLM opts = do
-  let optParseResult = parseCommandLineOptions defaultFlags opts
-  flags <- case optParseResult of
-    Left err -> error $ "error parsing options: " <> show err
-    Right (flags, unk) -> do
-        when (not $ null unk) $ do
-            error $ "unknown options: " <> show unk
-        pure flags
-  spec <- case mkTemplateSpec flags of
-    Left err -> error $ "Template spec error: " <> show err
-    Right ok -> pure ok
-  logger <- liftIO $ Log.initLogger (log_mode flags) (log_dir flags)
-  template <- liftIO $ do
-    raw <- loadTemplate spec
-    case raw of
-      Left err -> error $ "template parse error: " <> show err
-      Right ok -> pure ok
-  newTcRef $ PluginState
-    { candidates     = []
-    , writeLogEvent  = logger
-    , templateSpec   = spec
-    , parsedTemplate = template
-    , commandOptions = flags
-    }
--}
-
-data PluginInitError
-    = OptionParseError OptError
-    | UnknownOptionError [Token]
-    | TemplateSpecError TemplateError
-    | TemplateParseError TemplateError
-    deriving (Eq, Show)
-
+onLeftIO :: (MonadIO m) => (e1 -> e2) -> IO (Either e1 a) -> ExceptT e2 m a
+onLeftIO f act = liftIO act >>= either (throwError . f) pure
 
 
 
@@ -171,70 +167,82 @@ pluginName :: Text
 pluginName = "Ollama Plugin"
 
 fitPluginLLM
-    :: TcRef PluginState
+    :: TcRef (Either PluginError PluginState)
     -> TypedHole
     -> [HoleFit]
     -> GHC.IOEnv (Env TcGblEnv TcLclEnv) [HoleFit]
 fitPluginLLM ref hole fits = do
-    PluginState cands logger templateSpec template flags <- readTcRef ref
-    dflags <- getDynFlags
-    let Flags{..} = flags
-    let backend = getBackend flags
-    available_models <- liftIO $ listModels backend
-    liftIO $ when debug $ T.putStrLn $ "Running " <> pluginName <> " with flags:"
-    liftIO $ when debug $ print flags
+    refResult <- readTcRef ref
+    case refResult of
+        Left err -> do
+            liftIO $ putStrLn $ "Initializing OllamaHoles failed with the following error: " -- <> show err
+            pure fits
+        Right (PluginState cands logger templateSpec template flags) -> do
+            dflags <- getDynFlags
+            let Flags{..} = flags
+            let backend = getBackend flags
+            liftIO $ when debug $ T.putStrLn $ "Running " <> pluginName <> " with flags:"
+            liftIO $ when debug $ print flags
 
-    case available_models of
-        Nothing ->
-            error $ T.unpack pluginName <> ": No models available, check your configuration"
-        Just models -> do
-            unless (model_name `elem` models) $
-                error $ T.unpack pluginName
-                        <> ": Model "
-                        <> T.unpack model_name
-                        <> " not found. "
-                        <> ( if backend_name == "ollama"
-                                then "Use `ollama pull` to download the model, or "
-                                else ""
-                            )
-                        <> "specify another model using "
-                        <> "`-fplugin-opt=GHC.Plugin.OllamaHoles:model=<model_name>`\n"
-                        <> "Availble models: \n"
-                        <> T.unpack (T.unlines models)
+            crashOnError $ usingModel model_name backend backend_name
+
             liftIO $ when debug $ T.putStrLn $ pluginName <> ": Hole Found"
 
-            -- Prepare the prompt
-            gbl_env <- getGblEnv
-            let promptContext = getPromptContext hole fits gbl_env cands dflags
-            let promptContext'' = maybe "" encodePromptContext promptContext
-            docs <- if include_docs then getDocs cands else return ""
-            let env = mkTemplateEnv
-                    [ ("context" , promptContext'')
-                    , ("docs"    , T.pack docs)
-                    , ("numexpr" , T.pack (show num_expr))
-                    , ("backend" , backend_name)
-                    , ("model"   , model_name)
-                    , ("guidance", maybe "" (mconcat . pcGuidance) promptContext)
-                    ]
-            prompt'' <- case expandTemplate env template of
-                Left err -> error $ "Template substitution error: " <> show err
-                Right ok -> pure ok
+            h <- crashOnError $ atHole hole
+            prompt <- crashOnError $ prepareHoleFitPrompt dflags flags hole fits cands template
+            liftIO $ when debug $ do T.putStrLn $ "NEW PROMPT:\n\n" <> prompt <> "\n\n"
+            rsp <- crashOnError $ submitRequest backend prompt model_name model_options
+            extractHoleFitsFromResponse dflags prompt rsp logger hole h debug
 
-            case th_hole hole of
-                Just h -> do
-                    liftIO $ when debug $ do T.putStrLn $ "NEW PROMPT:\n\n" <> prompt'' <> "\n\n"
-                    res <- liftIO $ generateFits backend prompt'' model_name model_options
-                    case res of
-                        Right rsp ->
-                            extractHoleFitsFromResponse dflags prompt'' rsp logger hole h debug
-                        Left err -> do
-                            liftIO $
-                                when debug $
-                                    T.putStrLn $
-                                        pluginName <> " failed to generate a response.\n" <> T.pack err
-                            -- Return the original fits without modification
-                            return fits
-                Nothing -> return fits
+-- | Ensure that the specified model exists.
+usingModel :: Text -> Backend -> Text -> ExceptT PluginError TcM ()
+usingModel modelName backend backendName = do
+  available_models <- liftIO $ listModels backend
+  case available_models of
+    Nothing -> throwError NoModelsAvailable
+    Just models -> unless (modelName `elem` models) $
+      throwError $ ModelNotFound modelName models backendName
+
+-- | Build a prompt for the LLM from context.
+prepareHoleFitPrompt
+  :: DynFlags -> Flags -> TypedHole
+  -> [HoleFit]          -- Known hole fits provided by GHC
+  -> [HoleFitCandidate] -- Not yet checked; used for getting guidance
+  -> Template -> ExceptT PluginError TcM Text
+prepareHoleFitPrompt dflags flags hole fits cands template = do
+  gbl_env <- lift getGblEnv
+  docs <- lift $ if include_docs flags then getDocs cands else return ""
+  onLeftIO TemplateSubError $ pure $ expandTemplateWith template $ mkTemplateEnv
+    [ ("backend" , backend_name flags)
+    , ("model"   , model_name flags)
+    , ("numexpr" , T.pack (show $ num_expr flags))
+    , ("docs"    , T.pack docs)
+    , ("context" , maybe "" encodePromptContext $
+                        getPromptContext hole fits gbl_env cands dflags)
+    ]
+
+atHole
+  :: TypedHole -> ExceptT PluginError TcM Hole
+atHole hole = case th_hole hole of
+  Just ok -> pure ok
+  Nothing -> throwError $ TypedHoleNotFound hole
+
+-- Temporary
+crashOnError :: (Monad m) => ExceptT e m a -> m a
+crashOnError act = do
+    result <- runExceptT act
+    case result of
+        Left err -> error $ "ERROR: " -- <> show err
+        Right ok -> pure ok
+
+submitRequest
+  :: Backend -> Log.Prompt -> Text -> Maybe Value
+  -> ExceptT PluginError TcM Text
+submitRequest backend prompt modelName modelOptions = do
+  res <- liftIO $ generateFits backend prompt modelName modelOptions
+  case res of
+    Right rsp -> pure rsp
+    Left err -> throwError $ ResponseFailed $ T.pack err
 
 extractHoleFitsFromResponse
     :: DynFlags -> Log.Prompt -> Log.Response -> Log.Logger
@@ -251,25 +259,20 @@ extractHoleFitsFromResponse dflags prompt' rsp logger hole h debug = do
         mapM_ T.putStrLn surfaceUnique
         putStrLn ""
 
-    let parseCtx  = mkParseCtx dflags
-    let renameCtx = mkRenameCtx debug
-    let checkCtx  = mkCheckCtx debug hole
-    let prepCtx   = mkPrepCtx dflags (holeArity h)
-
     -- prepare candidates for semantic deduplication
     preparedE <- traverse
-        (pipelineCandidate parseCtx renameCtx checkCtx prepCtx)
+        (pipelineCandidate (mkParseCtx dflags) (mkRenameCtx debug)
+          (mkCheckCtx debug hole) (mkPrepCtx dflags (holeArity h)))
         surfaceUnique
 
     -- check that we reach the same conclusion as
     -- the original fit check
-    when debug $
-      regressionCheck hole surfaceUnique preparedE
+    when debug $ regressionCheck hole surfaceUnique preparedE
 
     let failures = [ (src, err) | (src, Left err) <- zip surfaceUnique preparedE ]
     let prepared = [ pc | Right pc <- preparedE ]
     let deduped  = dedupePreparedCandidates prepared
-    let fits'    = map (RawHoleFit . text . T.unpack . prSource) deduped
+    let holeFits = map (RawHoleFit . text . T.unpack . prSource) deduped
 
     liftIO $ when debug $ do
         when (not $ null failures) $ do
@@ -289,7 +292,7 @@ extractHoleFitsFromResponse dflags prompt' rsp logger hole h debug = do
     liftIO $ Log.writeLogEvent logger $ Log.mkLogEvent
         prompt' rsp (length rawLines) (length deduped) (length prepared)
 
-    return fits'
+    return holeFits
 
 holeArity :: Hole -> Int
 holeArity = length . fst . splitFunTys . hole_ty

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -115,20 +115,50 @@ data PluginError
 
 renderPluginError :: PluginError -> Text
 renderPluginError = \case
-  OptionParseError err -> mconcat
-    [ "Option parse error: ", T.pack (show err)
-    ]
+  OptionParseError err ->
+    "option parse error: " <> T.pack (show err)
+
+  UnknownOptionError toks ->
+    "unrecognized plugin option(s): "
+      <> T.intercalate ", " (map renderToken toks)
+
+  TemplateSpecError err ->
+    "template specification error: " <> T.pack (show err)
+
+  TemplateParseError err ->
+    "template load/parse error: " <> T.pack (show err)
+
+  TemplateSubError err ->
+    "template substitution error: " <> T.pack (show err)
+
+  NoModelsAvailable ->
+    "no models available; check your backend configuration"
+
   ModelNotFound modelName models backendName -> mconcat
-    [ "Model ", modelName, " not found. "
+    [ "model "
+    , modelName
+    , " not found for backend "
+    , backendName
+    , ". "
     , if backendName == "ollama"
-        then "Use `ollama pull` to download the model, or " else ""
+        then "Use `ollama pull` to download the model, or "
+        else ""
     , "specify another model using "
-    , "`-fplugin-opt=GHC.Plugin.OllamaHoles:model=<model_name>`\n"
-    , "Availble models: \n", T.unlines models
+    , "`-fplugin-opt=GHC.Plugin.OllamaHoles:model=`.\n"
+    , "Available models:\n"
+    , T.unlines models
     ]
-  _ -> mconcat
-    [ pluginName, ": ERROR - " --, T.pack (show err)
-    ]
+
+  TypedHoleNotFound _ ->
+    "could not locate the typed hole in the current context"
+
+  ResponseFailed msg ->
+    "backend request failed: " <> msg
+  where
+    renderToken :: Token -> Text
+    renderToken = \case
+      BooleanToken key -> key
+      ValueToken key val -> key <> "=" <> val
 
 
 
@@ -288,7 +318,7 @@ extractHoleFitsFromResponse st prompt rsp hole h = do
   when (not $ null prepared) $ do
     let numPrep = T.pack $ show $ length prepared
     debugMsg st $ "--- prepared for semantic-ish deduplication (" <> numPrep <> ") ---\n"
-      <> T.intercalate "\n" (foldMapFor prepared $ \pc -> (:[]) $ T.unlines
+      <> T.intercalate "\n" (flip foldMap prepared $ \pc -> (:[]) $ T.unlines
         [ "source: " <> prSource pc
         , "rank:   " <> T.pack (show $ prRank pc)
         , "key:    " <> T.pack (show $ prNormKey pc)
@@ -474,6 +504,3 @@ debugMsg st txt = liftIO $ when (debug $ commandOptions st) $
 
 onLeftIO :: (MonadIO m) => (e1 -> e2) -> IO (Either e1 a) -> ExceptT e2 m a
 onLeftIO f act = liftIO act >>= either (throwError . f) pure
-
-foldMapFor :: (Foldable t, Monoid m) => t a -> (a -> m) -> m
-foldMapFor = flip foldMap

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -8,7 +8,7 @@
 module GHC.Plugin.OllamaHoles where
 
 import Control.Monad (unless, when, forM_, (>=>))
-import Control.Monad.Except (ExceptT, runExceptT, MonadError(..))
+import Control.Monad.Except (ExceptT, runExceptT, MonadError(..), liftEither)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.Class (MonadTrans(..))
 import Control.Monad.Trans.Except ()
@@ -166,42 +166,52 @@ getBackend Flags{..} = error $ "unknown backend: " <> T.unpack backend_name
 pluginName :: Text
 pluginName = "Ollama Plugin"
 
+
+
 fitPluginLLM
+  :: TcRef (Either PluginError PluginState)
+  -> TypedHole
+  -> [HoleFit] -- Known hole fits from GHC
+  -> TcM [HoleFit]
+fitPluginLLM ref hole fits = do
+  result <- runExceptT $ tryFitPluginLLM ref hole fits
+  case result of
+    Right ok -> pure ok
+    Left err -> do
+      liftIO $ T.putStrLn $ pluginName <> ": " <> renderPluginError err
+      pure fits
+
+tryFitPluginLLM
     :: TcRef (Either PluginError PluginState)
     -> TypedHole
-    -> [HoleFit]
-    -> GHC.IOEnv (Env TcGblEnv TcLclEnv) [HoleFit]
-fitPluginLLM ref hole fits = do
-    refResult <- readTcRef ref
-    case refResult of
-        Left err -> do
-            liftIO $ putStrLn $ "Initializing OllamaHoles failed with the following error: " -- <> show err
-            pure fits
-        Right (PluginState cands logger templateSpec template flags) -> do
-            dflags <- getDynFlags
-            let Flags{..} = flags
-            let backend = getBackend flags
-            liftIO $ when debug $ T.putStrLn $ "Running " <> pluginName <> " with flags:"
-            liftIO $ when debug $ print flags
+    -> [HoleFit] -- Known hole fits from GHC
+    -> ExceptT PluginError TcM [HoleFit]
+tryFitPluginLLM ref typedHole fits = do
+    PluginState cands logger templateSpec template flags <- readTcRef ref >>= liftEither
+    dflags <- getDynFlags
+    let debugMode = debug flags
+    liftIO $ when debugMode $ T.putStrLn $ "Running " <> pluginName <> " with flags:"
+    liftIO $ when debugMode $ print flags
 
-            crashOnError $ usingModel model_name backend backend_name
+    checkModel flags
 
-            liftIO $ when debug $ T.putStrLn $ pluginName <> ": Hole Found"
+    liftIO $ when debugMode $ T.putStrLn $ pluginName <> ": Hole Found"
 
-            h <- crashOnError $ atHole hole
-            prompt <- crashOnError $ prepareHoleFitPrompt dflags flags hole fits cands template
-            liftIO $ when debug $ do T.putStrLn $ "NEW PROMPT:\n\n" <> prompt <> "\n\n"
-            rsp <- crashOnError $ submitRequest backend prompt model_name model_options
-            extractHoleFitsFromResponse dflags prompt rsp logger hole h debug
+    h <- atHole typedHole
+    prompt <- prepareHoleFitPrompt dflags flags typedHole fits cands template
+    liftIO $ when debugMode $ do T.putStrLn $ "NEW PROMPT:\n\n" <> prompt <> "\n\n"
+    rsp <- submitRequest flags prompt
+    lift $ extractHoleFitsFromResponse dflags prompt rsp logger typedHole h debugMode
 
 -- | Ensure that the specified model exists.
-usingModel :: Text -> Backend -> Text -> ExceptT PluginError TcM ()
-usingModel modelName backend backendName = do
+checkModel :: Flags -> ExceptT PluginError TcM ()
+checkModel flags = do
+  let backend = getBackend flags
   available_models <- liftIO $ listModels backend
   case available_models of
     Nothing -> throwError NoModelsAvailable
-    Just models -> unless (modelName `elem` models) $
-      throwError $ ModelNotFound modelName models backendName
+    Just models -> unless (model_name flags `elem` models) $
+      throwError $ ModelNotFound (model_name flags) models (backend_name flags)
 
 -- | Build a prompt for the LLM from context.
 prepareHoleFitPrompt
@@ -227,19 +237,12 @@ atHole hole = case th_hole hole of
   Just ok -> pure ok
   Nothing -> throwError $ TypedHoleNotFound hole
 
--- Temporary
-crashOnError :: (Monad m) => ExceptT e m a -> m a
-crashOnError act = do
-    result <- runExceptT act
-    case result of
-        Left err -> error $ "ERROR: " -- <> show err
-        Right ok -> pure ok
-
 submitRequest
-  :: Backend -> Log.Prompt -> Text -> Maybe Value
+  :: Flags -> Log.Prompt
   -> ExceptT PluginError TcM Text
-submitRequest backend prompt modelName modelOptions = do
-  res <- liftIO $ generateFits backend prompt modelName modelOptions
+submitRequest flags prompt = do
+  let backend = getBackend flags
+  res <- liftIO $ generateFits backend prompt (model_name flags) (model_options flags)
   case res of
     Right rsp -> pure rsp
     Left err -> throwError $ ResponseFailed $ T.pack err

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -12,7 +12,6 @@ import Control.Monad (unless, when, forM_, (>=>))
 import Control.Monad.Except (ExceptT, runExceptT, MonadError(..), liftEither)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.Class (MonadTrans(..))
-import Control.Monad.Trans.Except ()
 import Data.Char (isSpace)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -111,7 +110,11 @@ data PluginError
   | ModelNotFound Text [Text] Text
   | TypedHoleNotFound TypedHole
   | ResponseFailed Text
-  -- deriving (Eq, Show)
+
+isSilentError :: PluginError -> Bool
+isSilentError = \case
+  TypedHoleNotFound _ -> True
+  _                   -> False
 
 renderPluginError :: PluginError -> Text
 renderPluginError = \case
@@ -179,9 +182,9 @@ tryPluginInitLLM opts = do
     Right (fs, []) -> pure fs
     Right (_, unk) -> throwError $ UnknownOptionError unk
     Left err       -> throwError $ OptionParseError err
-  spec <- onLeftIO TemplateSpecError $ pure $ mkTemplateSpec flags
+  spec <- liftEitherIO TemplateSpecError $ pure $ mkTemplateSpec flags
   logger <- liftIO $ Log.initLogger (log_mode flags) (log_dir flags)
-  template <- onLeftIO TemplateParseError $ loadTemplate spec
+  template <- liftEitherIO TemplateParseError $ loadTemplate spec
   pure $ PluginState
     { candidates     = []
     , writeLogEvent  = logger
@@ -205,7 +208,8 @@ fitPluginLLM ref hole fits = do
   case result of
     Right ok -> pure ok
     Left err -> do
-      liftIO $ T.putStrLn $ pluginName <> ": " <> renderPluginError err
+      unless (isSilentError err) $ liftIO $
+        T.putStrLn $ pluginName <> ": " <> renderPluginError err
       pure fits
 
 tryFitPluginLLM
@@ -246,7 +250,7 @@ prepareHoleFitPrompt st hole fits = do
   dflags <- lift getDynFlags
   docs <- lift $ if include_docs flags
     then getDocs (candidates st) else return ""
-  onLeftIO TemplateSubError $ pure $
+  liftEitherIO TemplateSubError $ pure $
     expandTemplateWith (parsedTemplate st) $ mkTemplateEnv
       [ ("backend" , backend_name flags)
       , ("model"   , model_name flags)
@@ -502,5 +506,5 @@ debugMsg :: (MonadIO m) => PluginState -> Text -> m ()
 debugMsg st txt = liftIO $ when (debug $ commandOptions st) $
   T.putStrLn $ pluginName <> ": " <> txt
 
-onLeftIO :: (MonadIO m) => (e1 -> e2) -> IO (Either e1 a) -> ExceptT e2 m a
-onLeftIO f act = liftIO act >>= either (throwError . f) pure
+liftEitherIO :: (MonadIO m) => (e1 -> e2) -> IO (Either e1 a) -> ExceptT e2 m a
+liftEitherIO f act = liftIO act >>= either (throwError . f) pure

--- a/src/GHC/Plugin/OllamaHoles/Candidate.hs
+++ b/src/GHC/Plugin/OllamaHoles/Candidate.hs
@@ -380,12 +380,12 @@ data CandidateError
     | CandidateRejected Text
     deriving (Eq, Show)
 
-renderCandidateError :: Text -> CandidateError -> String
+renderCandidateError :: Text -> CandidateError -> Text
 renderCandidateError src = \case
-    CandidateParseError msg  -> "parse failed: " <> T.unpack src <> "\n  " <> T.unpack msg
-    CandidateRenameError msg -> "rename failed: " <> T.unpack src <> "\n  " <> T.unpack msg
-    CandidateTypeError msg   -> "type inference or hole-fit check failed: " <> T.unpack src <> "\n  " <> T.unpack msg
-    CandidateRejected msg    -> "rejected: " <> T.unpack src <> "\n  " <> T.unpack msg
+    CandidateParseError msg  -> "parse failed: " <> src <> "\n  " <> msg
+    CandidateRenameError msg -> "rename failed: " <> src <> "\n  " <> msg
+    CandidateTypeError msg   -> "type inference or hole-fit check failed: " <> src <> "\n  " <> msg
+    CandidateRejected msg    -> "rejected: " <> src <> "\n  " <> msg
 
 
 

--- a/src/GHC/Plugin/OllamaHoles/Template.hs
+++ b/src/GHC/Plugin/OllamaHoles/Template.hs
@@ -14,6 +14,7 @@ module GHC.Plugin.OllamaHoles.Template
     , loadTemplate
     , parseTemplate
     , expandTemplate
+    , expandTemplateWith
     --
     , unsafeCreateRawTemplateName
     ) where
@@ -81,6 +82,10 @@ expandTemplate env (Template exprs) = do
         expandTemplateExpr env expr = case expr of
             TemplateChunk txt -> Right txt
             TemplateVar var -> lookupPlaceholder env var
+
+-- | Argument flipped @expandTemplate@.
+expandTemplateWith :: Template -> TemplateEnv -> Either TemplateError Text
+expandTemplateWith = flip expandTemplate
 
 collectEithers
     :: forall a b u v. ([a] -> u) -> ([b] -> v) -> [Either a b] -> Either u v


### PR DESCRIPTION
Addresses https://github.com/tweag/OllamaHoles/issues/6

Right now the plugin uses `error` to bail out of any errors. For this task we will handle these more gracefully by printing a message to stdout and letting compilation proceed with GHC's list of hole fits.