### PR TITLE
Add BackendSlug type

### DIFF
--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -131,6 +131,7 @@ library
 
     -- Modules included in this library but not exported.
     other-modules: GHC.Plugin.OllamaHoles.Backend
+                 , GHC.Plugin.OllamaHoles.Backend.Common
                  , GHC.Plugin.OllamaHoles.Backend.Ollama
                  , GHC.Plugin.OllamaHoles.Backend.OpenAI
                  , GHC.Plugin.OllamaHoles.Backend.Gemini

--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -125,13 +125,13 @@ library
 
     -- Modules exported by the library.
     exposed-modules:  GHC.Plugin.OllamaHoles
+                    , GHC.Plugin.OllamaHoles.Backend
                     , GHC.Plugin.OllamaHoles.Template
                     , GHC.Plugin.OllamaHoles.Options
                     , GHC.Plugin.OllamaHoles.Logger
 
     -- Modules included in this library but not exported.
-    other-modules: GHC.Plugin.OllamaHoles.Backend
-                 , GHC.Plugin.OllamaHoles.Backend.Common
+    other-modules: GHC.Plugin.OllamaHoles.Backend.Common
                  , GHC.Plugin.OllamaHoles.Backend.Ollama
                  , GHC.Plugin.OllamaHoles.Backend.OpenAI
                  , GHC.Plugin.OllamaHoles.Backend.Gemini

--- a/spec/GHC/Plugin/OllamaHoles/Options/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Options/Spec.hs
@@ -26,6 +26,9 @@ import GHC.Plugin.OllamaHoles.Template
   , TemplateError(..)
   , unsafeCreateRawTemplateName
   )
+import GHC.Plugin.OllamaHoles.Backend
+  ( BackendSlug(..)
+  )
 
 tests :: TestTree
 tests =
@@ -66,7 +69,7 @@ parserSimpleTests =
 
     , testCase "backend= sets backend_name" $ do
         (flags, unknowns) <- expectParseOk ["backend=openai"]
-        backend_name flags @?= "openai"
+        backend_name flags @?= OpenAI
         unknowns @?= []
 
     , testCase "openai_base_url= sets openai_base_url" $ do
@@ -128,7 +131,7 @@ parserPrecedenceTests =
 
     , testCase "leftmost backend= wins" $ do
         (flags, unknowns) <- expectParseOk ["backend=ollama", "backend=openai"]
-        backend_name flags @?= "ollama"
+        backend_name flags @?= Ollama
         unknowns @?= []
 
     , testCase "leftmost openai_base_url= wins" $ do
@@ -183,7 +186,7 @@ parserPrecedenceTests =
           , "backend=openai"
           ]
         model_name flags @?= "first"
-        backend_name flags @?= "ollama"
+        backend_name flags @?= Ollama
         debug flags @?= True
         include_docs flags @?= True
         unknowns @?= []
@@ -211,7 +214,7 @@ parserFailureTests =
 
     , testCase "value-like unknown options are reported and do not block recognized options" $ do
         (flags, unknowns) <- expectParseOk ["bogus=thing", "backend=openai"]
-        backend_name flags @?= "openai"
+        backend_name flags @?= OpenAI
         unknowns @?= [ValueToken "bogus" "thing"]
     ]
 

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -107,7 +107,7 @@ data PluginError
   | TemplateParseError TemplateError
   | TemplateSubError TemplateError
   | NoModelsAvailable
-  | ModelNotFound Text [Text] Text
+  | ModelNotFound Text [Text] BackendSlug
   | TypedHoleNotFound TypedHole
   | ResponseFailed Text
 
@@ -145,9 +145,9 @@ renderPluginError = \case
     [ "model "
     , modelName
     , " not found for backend "
-    , backendName
+    , renderBackendSlug backendName
     , ". "
-    , if backendName == "ollama"
+    , if backendName == Ollama
         then "Use `ollama pull` to download the model, or "
         else ""
     , "specify another model using "
@@ -257,7 +257,7 @@ prepareHoleFitPrompt st hole fits = do
     then getDocs (candidates st) else return ""
   liftEitherIO TemplateSubError $ pure $
     expandTemplateWith (parsedTemplate st) $ mkTemplateEnv
-      [ ("backend" , backend_name flags)
+      [ ("backend" , renderBackendSlug $ backend_name flags)
       , ("model"   , model_name flags)
       , ("numexpr" , T.pack (show $ num_expr flags))
       , ("docs"    , T.pack docs)
@@ -497,10 +497,10 @@ mkTemplateSpec Flags{..} = do
 
 -- | Determine which backend to use
 getBackend :: Flags -> Backend
-getBackend Flags{backend_name = "ollama"} = ollamaBackend
-getBackend Flags{backend_name = "gemini"} = geminiBackend
-getBackend Flags{backend_name = "openai", ..} = openAICompatibleBackend openai_base_url openai_key_name
-getBackend Flags{..} = error $ "unknown backend: " <> T.unpack backend_name -- TODO
+getBackend flags = case backend_name flags of
+    Gemini -> geminiBackend
+    Ollama -> ollamaBackend
+    OpenAI -> openAICompatibleBackend (openai_base_url flags) (openai_key_name flags)
 
 
 

--- a/src/GHC/Plugin/OllamaHoles/Backend.hs
+++ b/src/GHC/Plugin/OllamaHoles/Backend.hs
@@ -1,12 +1,38 @@
--- | The Backend data type
-module GHC.Plugin.OllamaHoles.Backend (Backend(..)) where
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
+
+module GHC.Plugin.OllamaHoles.Backend
+  ( module GHC.Plugin.OllamaHoles.Backend.Common
+  , module GHC.Plugin.OllamaHoles.Backend.Gemini
+  , module GHC.Plugin.OllamaHoles.Backend.Ollama
+  , module GHC.Plugin.OllamaHoles.Backend.OpenAI
+  , BackendSlug(..)
+  , parseBackendSlug
+  , renderBackendSlug
+  ) where
 
 import Data.Text (Text)
-import Data.Aeson (Value)
 
--- | Backend to use.
-data Backend = Backend
-    { listModels :: IO (Maybe [Text])
-    , generateFits :: Text -> Text -> Maybe Value -> IO (Either String Text)
-    }
+import GHC.Plugin.OllamaHoles.Backend.Common
+import GHC.Plugin.OllamaHoles.Backend.Gemini
+import GHC.Plugin.OllamaHoles.Backend.Ollama
+import GHC.Plugin.OllamaHoles.Backend.OpenAI
 
+data BackendSlug
+  = Gemini
+  | Ollama
+  | OpenAI
+  deriving (Eq, Show)
+
+parseBackendSlug :: Text -> Maybe BackendSlug
+parseBackendSlug = \case
+  "gemini" -> Just Gemini
+  "ollama" -> Just Ollama
+  "openai" -> Just OpenAI
+  _        -> Nothing
+
+renderBackendSlug :: BackendSlug -> Text
+renderBackendSlug = \case
+  Gemini -> "gemini"
+  Ollama -> "ollama"
+  OpenAI -> "openai"

--- a/src/GHC/Plugin/OllamaHoles/Backend/Common.hs
+++ b/src/GHC/Plugin/OllamaHoles/Backend/Common.hs
@@ -1,0 +1,11 @@
+-- | The Backend data type
+module GHC.Plugin.OllamaHoles.Backend.Common (Backend(..)) where
+
+import Data.Text (Text)
+import Data.Aeson (Value)
+
+-- | Backend to use.
+data Backend = Backend
+    { listModels :: IO (Maybe [Text])
+    , generateFits :: Text -> Text -> Maybe Value -> IO (Either String Text)
+    }

--- a/src/GHC/Plugin/OllamaHoles/Backend/Gemini.hs
+++ b/src/GHC/Plugin/OllamaHoles/Backend/Gemini.hs
@@ -12,7 +12,7 @@ import Data.Aeson.Types (Parser, parseMaybe)
 
 import Data.Text (Text)
 import qualified Data.Text as T
-import GHC.Plugin.OllamaHoles.Backend
+import GHC.Plugin.OllamaHoles.Backend.Common
 import Data.Maybe
 
 -- | The Gemini backend

--- a/src/GHC/Plugin/OllamaHoles/Backend/Ollama.hs
+++ b/src/GHC/Plugin/OllamaHoles/Backend/Ollama.hs
@@ -7,7 +7,7 @@ module GHC.Plugin.OllamaHoles.Backend.Ollama (ollamaBackend) where
 import Ollama (GenerateOps (..))
 import Ollama qualified
 
-import GHC.Plugin.OllamaHoles.Backend
+import GHC.Plugin.OllamaHoles.Backend.Common
 
 -- | The locally hosted ollama backend
 ollamaBackend :: Backend

--- a/src/GHC/Plugin/OllamaHoles/Backend/OpenAI.hs
+++ b/src/GHC/Plugin/OllamaHoles/Backend/OpenAI.hs
@@ -14,7 +14,7 @@ import qualified Data.Aeson as Aeson
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
-import GHC.Plugin.OllamaHoles.Backend
+import GHC.Plugin.OllamaHoles.Backend.Common
 import Data.Maybe (fromMaybe)
 import Text.URI (mkURI)
 

--- a/src/GHC/Plugin/OllamaHoles/Options.hs
+++ b/src/GHC/Plugin/OllamaHoles/Options.hs
@@ -19,6 +19,7 @@ import Data.Text qualified as T
 import Text.Read (readMaybe)
 
 import GHC.Plugin.OllamaHoles.Logger (LogMode(..))
+import GHC.Plugin.OllamaHoles.Backend (BackendSlug(..), parseBackendSlug)
 
 
 
@@ -32,7 +33,7 @@ parseCommandLineOptions defaults opts = do
 -- | Command line options for the plugin
 data Flags = Flags
     { model_name          :: Text
-    , backend_name        :: Text
+    , backend_name        :: BackendSlug
     , num_expr            :: Int
     , debug               :: Bool
     , include_docs        :: Bool
@@ -50,7 +51,7 @@ data Flags = Flags
 defaultFlags :: Flags
 defaultFlags = Flags
     { model_name          = "qwen3:latest"
-    , backend_name        = "ollama"
+    , backend_name        = Ollama
     , num_expr            = 5
     , debug               = False
     , include_docs        = False
@@ -157,7 +158,9 @@ interpret flag = case flag of
         makeOk $ \fs -> fs { model_name = name }
 
     SetBackend name -> requireNonEmpty "backend" name $
-        makeOk $ \fs -> fs { backend_name = name }
+        case parseBackendSlug name of
+            Just slug -> makeOk $ \fs -> fs { backend_name = slug }
+            Nothing -> Left (InvalidBackend name)
 
     EnableDebug -> makeOk $ \fs -> fs
         { debug = True }
@@ -227,4 +230,5 @@ data OptError
     | InvalidInt FlagName Text
     | InvalidJson FlagName Text String
     | InvalidEnum FlagName Text [Text]
+    | InvalidBackend Text
     deriving (Eq, Show)


### PR DESCRIPTION
Addresses https://github.com/tweag/OllamaHoles/issues/6

The number of backends is small and unlikely to grow very fast. This patch adds a type to represent the supported backends and parses into it so that unrecognized backends present as option errors. This removes another call to `error`.