### PR TITLE
Add triggers

### DIFF
--- a/Test/Main.hs
+++ b/Test/Main.hs
@@ -14,5 +14,5 @@ import GHC.TypeError
 main :: IO ()
 main = do
   let _guide = Proxy :: Proxy (Text "The function should sort the list and then show each element")
-  let k = (_b :: [Int] -> [String])
+  let k = (_llm :: [Int] -> [String])
   print (k [1, 2, 3])

--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -129,6 +129,7 @@ library
                     , GHC.Plugin.OllamaHoles.Template
                     , GHC.Plugin.OllamaHoles.Options
                     , GHC.Plugin.OllamaHoles.Logger
+                    , GHC.Plugin.OllamaHoles.Trigger
 
     -- Modules included in this library but not exported.
     other-modules: GHC.Plugin.OllamaHoles.Backend.Common
@@ -212,6 +213,7 @@ test-suite ollama-holes-spec
     , GHC.Plugin.OllamaHoles.Template.Expand.Spec
     , GHC.Plugin.OllamaHoles.Options.Spec
     , GHC.Plugin.OllamaHoles.Logger.Spec
+    , GHC.Plugin.OllamaHoles.Trigger.Spec
   build-depends:
       base
     , ollama-holes-plugin

--- a/spec/GHC/Plugin/OllamaHoles/Options/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Options/Spec.hs
@@ -20,6 +20,7 @@ import GHC.Plugin.OllamaHoles.Options
 import GHC.Plugin.OllamaHoles.Logger
   ( LogMode(..)
   )
+import GHC.Plugin.OllamaHoles.Trigger
 import GHC.Plugin.OllamaHoles.Template
   ( TemplateSpec(..)
   , TemplateSource(..)
@@ -39,6 +40,7 @@ tests =
     , parserFailureTests
     , parserLogOptionTests
     , templateParserTests
+    , triggerParserTests
     , mkTemplateSpecTests
     ]
 
@@ -216,6 +218,26 @@ parserFailureTests =
         (flags, unknowns) <- expectParseOk ["bogus=thing", "backend=openai"]
         backend_name flags @?= OpenAI
         unknowns @?= [ValueToken "bogus" "thing"]
+
+    , testCase "missing value for model is structured error" $ do
+        parseCommandLineOptions defaultFlags ["model"]
+          @?= Left (MissingValue "model")
+
+    , testCase "missing value for backend is structured error" $ do
+        parseCommandLineOptions defaultFlags ["backend"]
+          @?= Left (MissingValue "backend")
+
+    , testCase "unexpected value for debug is structured error" $ do
+        parseCommandLineOptions defaultFlags ["debug=true"]
+          @?= Left (UnexpectedValue "debug" "true")
+
+    , testCase "unexpected value for include-docs is structured error" $ do
+        parseCommandLineOptions defaultFlags ["include-docs=yes"]
+          @?= Left (UnexpectedValue "include-docs" "yes")
+
+    , testCase "empty option is structured error" $ do
+        parseCommandLineOptions defaultFlags [""]
+          @?= Left EmptyOption
     ]
 
 parserLogOptionTests :: TestTree
@@ -430,4 +452,59 @@ mkTemplateSpecTests =
         unknowns @?= []
         mkTemplateSpec flags
           @?= Left (InvalidTemplateName "../secrets")
+    ]
+
+triggerParserTests :: TestTree
+triggerParserTests =
+  testGroup "parseCommandLineOptions trigger options"
+    [ testCase "default trigger policy is the module default" $ do
+        (flags, unknowns) <- expectParseOk []
+        trigger_policy flags @?= defaultTriggerPolicy
+        unknowns @?= []
+
+    , testCase "trigger=all sets TriggerAll" $ do
+        (flags, unknowns) <- expectParseOk ["trigger=all"]
+        trigger_policy flags @?= TriggerAll
+        unknowns @?= []
+
+    , testCase "trigger=none sets TriggerNone" $ do
+        (flags, unknowns) <- expectParseOk ["trigger=none"]
+        trigger_policy flags @?= TriggerNone
+        unknowns @?= []
+
+    , testCase "trigger=prefix:foo sets TriggerPrefix foo" $ do
+        (flags, unknowns) <- expectParseOk ["trigger=prefix:foo"]
+        trigger_policy flags @?= TriggerPrefix "foo"
+        unknowns @?= []
+
+    , testCase "leftmost trigger wins" $ do
+        (flags, unknowns) <- expectParseOk
+          [ "trigger=prefix:foo"
+          , "trigger=none"
+          ]
+        trigger_policy flags @?= TriggerPrefix "foo"
+        unknowns @?= []
+
+    , testCase "trigger interleaves with other options" $ do
+        (flags, unknowns) <- expectParseOk
+          [ "model=qwen3"
+          , "trigger=prefix:foo"
+          , "debug"
+          ]
+        model_name flags @?= "qwen3"
+        debug flags @?= True
+        trigger_policy flags @?= TriggerPrefix "foo"
+        unknowns @?= []
+
+    , testCase "missing trigger value is structured error" $ do
+        parseCommandLineOptions defaultFlags ["trigger"]
+          @?= Left (MissingValue "trigger")
+
+    , testCase "empty trigger value is structured error" $ do
+        parseCommandLineOptions defaultFlags ["trigger="]
+          @?= Left (EmptyValue "trigger")
+
+    , testCase "invalid trigger policy is structured error" $ do
+        parseCommandLineOptions defaultFlags ["trigger=prefix:_foo"]
+          @?= Left (InvalidTriggerPolicy "prefix:_foo" (InvalidTriggerPrefix "_foo"))
     ]

--- a/spec/GHC/Plugin/OllamaHoles/Trigger/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Trigger/Spec.hs
@@ -1,0 +1,274 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module GHC.Plugin.OllamaHoles.Trigger.Spec (tests) where
+
+import Data.Maybe (isJust, isNothing)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck ((===))
+import Test.Tasty.QuickCheck qualified as QC
+
+import GHC.Plugin.OllamaHoles.Trigger
+  ( TriggerPolicy(..)
+  , TriggerPolicyError(..)
+  , TriggerMatch(..)
+  , defaultTriggerPolicy
+  , parseTriggerPolicy
+  , renderTriggerPolicy
+  , shouldTriggerHole
+  , matchTriggerPolicy
+  , mkTriggeredHoleName
+  )
+
+tests :: TestTree
+tests =
+  testGroup "Trigger"
+    [ unitTests
+    , propertyTests
+    ]
+
+
+-- Unit tests
+-------------
+
+unitTests :: TestTree
+unitTests =
+  testGroup "unit"
+    [ parsingTests
+    , matchingTests
+    , namingTests
+    , defaultTests
+    ]
+
+parsingTests :: TestTree
+parsingTests =
+  testGroup "parseTriggerPolicy"
+    [ testCase "parses all" $
+        parseTriggerPolicy "all" @?= Right TriggerAll
+
+    , testCase "parses none" $
+        parseTriggerPolicy "none" @?= Right TriggerNone
+
+    , testCase "parses prefix policy" $
+        parseTriggerPolicy "prefix:foo" @?= Right (TriggerPrefix "foo")
+
+    , testCase "trims outer whitespace" $
+        parseTriggerPolicy "   prefix:foo   " @?= Right (TriggerPrefix "foo")
+
+    , testCase "rejects empty policy" $
+        parseTriggerPolicy "" @?= Left EmptyTriggerPolicy
+
+    , testCase "rejects unknown policy" $
+        parseTriggerPolicy "wat" @?= Left (UnknownTriggerPolicy "wat")
+
+    , testCase "rejects missing prefix after prefix:" $
+        parseTriggerPolicy "prefix:" @?= Left MissingTriggerPrefix
+
+    , testCase "rejects leading underscore in prefix" $
+        parseTriggerPolicy "prefix:_foo" @?= Left (InvalidTriggerPrefix "_foo")
+
+    , testCase "rejects uppercase-starting prefix" $
+        parseTriggerPolicy "prefix:Foo" @?= Left (InvalidTriggerPrefix "Foo")
+
+    , testCase "rejects digit-starting prefix" $
+        parseTriggerPolicy "prefix:1foo" @?= Left (InvalidTriggerPrefix "1foo")
+
+    , testCase "rejects hyphen in prefix" $
+        parseTriggerPolicy "prefix:foo-bar" @?= Left (InvalidTriggerPrefix "foo-bar")
+
+    , testCase "rejects slash in prefix" $
+        parseTriggerPolicy "prefix:foo/bar" @?= Left (InvalidTriggerPrefix "foo/bar")
+
+    , testCase "rejects dot in prefix" $
+        parseTriggerPolicy "prefix:foo.bar" @?= Left (InvalidTriggerPrefix "foo.bar")
+
+    , testCase "accepts digits after first character" $
+        parseTriggerPolicy "prefix:foo1" @?= Right (TriggerPrefix "foo1")
+
+    , testCase "accepts underscore after first character" $
+        parseTriggerPolicy "prefix:foo_bar" @?= Right (TriggerPrefix "foo_bar")
+
+    , testCase "accepts apostrophe after first character" $
+        parseTriggerPolicy "prefix:foo'" @?= Right (TriggerPrefix "foo'")
+    ]
+
+matchingTests :: TestTree
+matchingTests =
+  testGroup "matching"
+    [ testCase "TriggerAll always matches" $
+        matchTriggerPolicy TriggerAll "_anything"
+          @?= Just (TriggerMatch "_anything" "_anything")
+
+    , testCase "TriggerNone never matches" $
+        matchTriggerPolicy TriggerNone "_anything"
+          @?= Nothing
+
+    , testCase "prefix match succeeds on exact prefix hole" $
+        matchTriggerPolicy (TriggerPrefix "foo") "_foo"
+          @?= Just (TriggerMatch "_foo" "")
+
+    , testCase "prefix match succeeds with numeric suffix" $
+        matchTriggerPolicy (TriggerPrefix "foo") "_foo1"
+          @?= Just (TriggerMatch "_foo1" "1")
+
+    , testCase "prefix match succeeds with alphabetic suffix" $
+        matchTriggerPolicy (TriggerPrefix "foo") "_foodefault"
+          @?= Just (TriggerMatch "_foodefault" "default")
+
+    , testCase "prefix match succeeds with underscore in suffix" $
+        matchTriggerPolicy (TriggerPrefix "foo") "_foo_bar"
+          @?= Just (TriggerMatch "_foo_bar" "_bar")
+
+    , testCase "prefix match succeeds with apostrophe in suffix" $
+        matchTriggerPolicy (TriggerPrefix "foo") "_foo'"
+          @?= Just (TriggerMatch "_foo'" "'")
+
+    , testCase "prefix match rejects missing leading underscore" $
+        matchTriggerPolicy (TriggerPrefix "foo") "foo"
+          @?= Nothing
+
+    , testCase "prefix match rejects wrong prefix" $
+        matchTriggerPolicy (TriggerPrefix "foo") "_bar"
+          @?= Nothing
+
+    , testCase "prefix match rejects invalid suffix characters" $
+        matchTriggerPolicy (TriggerPrefix "foo") "_foo-bar"
+          @?= Nothing
+
+    , testCase "prefix match rejects empty prefix policy at match time" $
+        matchTriggerPolicy (TriggerPrefix "") "_anything"
+          @?= Nothing
+
+    , testCase "shouldTriggerHole agrees with matchTriggerPolicy on hit" $
+        shouldTriggerHole (TriggerPrefix "foo") "_foo123" @?= True
+
+    , testCase "shouldTriggerHole agrees with matchTriggerPolicy on miss" $
+        shouldTriggerHole (TriggerPrefix "foo") "_bar123" @?= False
+    ]
+
+namingTests :: TestTree
+namingTests =
+  testGroup "naming"
+    [ testCase "mkTriggeredHoleName reconstructs exact prefix hole" $
+        mkTriggeredHoleName "foo" "" @?= "_foo"
+
+    , testCase "mkTriggeredHoleName reconstructs suffixed hole" $
+        mkTriggeredHoleName "foo" "1" @?= "_foo1"
+
+    , testCase "empty suffix and default suffix remain distinct" $
+        mkTriggeredHoleName "foo" ""
+          /= mkTriggeredHoleName "foo" "default"
+          @? "expected distinct reconstructed names"
+
+    , testCase "empty suffix and numeric suffix remain distinct" $
+        mkTriggeredHoleName "foo" ""
+          /= mkTriggeredHoleName "foo" "1"
+          @? "expected distinct reconstructed names"
+    ]
+
+defaultTests :: TestTree
+defaultTests =
+  testGroup "defaults"
+    [ testCase "default trigger policy is llm prefix" $
+        defaultTriggerPolicy @?= TriggerPrefix "llm"
+
+    , testCase "default trigger policy matches _llm" $
+        shouldTriggerHole defaultTriggerPolicy "_llm" @?= True
+
+    , testCase "default trigger policy matches _llm1" $
+        shouldTriggerHole defaultTriggerPolicy "_llm1" @?= True
+
+    , testCase "default trigger policy rejects plain typed holes" $
+        shouldTriggerHole defaultTriggerPolicy "_" @?= False
+    ]
+
+
+-- Property tests
+-----------------
+
+propertyTests :: TestTree
+propertyTests =
+  testGroup "properties"
+    [ QC.testProperty "render/parse roundtrip for valid policies" $
+        QC.forAll genTriggerPolicy $ \pol ->
+          parseTriggerPolicy (renderTriggerPolicy pol) === Right pol
+
+    , QC.testProperty "shouldTriggerHole agrees with matchTriggerPolicy" $
+        QC.forAll genTriggerPolicy $ \pol ->
+        QC.forAll genHoleName $ \nm ->
+          shouldTriggerHole pol nm === isJust (matchTriggerPolicy pol nm)
+
+    , QC.testProperty "prefix matching is bijective with mkTriggeredHoleName" $
+        QC.forAll genValidPrefix $ \pfx ->
+        QC.forAll genValidSuffix $ \sfx ->
+          matchTriggerPolicy (TriggerPrefix pfx) (mkTriggeredHoleName pfx sfx)
+            === Just (TriggerMatch (mkTriggeredHoleName pfx sfx) sfx)
+
+    , QC.testProperty "mkTriggeredHoleName distinguishes distinct suffixes" $
+        QC.forAll genValidPrefix $ \pfx ->
+        QC.forAll genDistinctSuffixPair $ \(s1, s2) ->
+          mkTriggeredHoleName pfx s1 /= mkTriggeredHoleName pfx s2
+
+    , QC.testProperty "TriggerNone never matches any generated hole name" $
+        QC.forAll genHoleName $ \nm ->
+          isNothing (matchTriggerPolicy TriggerNone nm)
+
+    , QC.testProperty "TriggerAll always matches any generated hole name" $
+        QC.forAll genHoleName $ \nm ->
+          matchTriggerPolicy TriggerAll nm === Just (TriggerMatch nm nm)
+
+    , QC.testProperty "valid prefix policies parse successfully" $
+        QC.forAll genValidPrefix $ \pfx ->
+          parseTriggerPolicy ("prefix:" <> pfx) === Right (TriggerPrefix pfx)
+
+    , QC.testProperty "constructed triggered names always trigger for same prefix" $
+        QC.forAll genValidPrefix $ \pfx ->
+        QC.forAll genValidSuffix $ \sfx ->
+          shouldTriggerHole (TriggerPrefix pfx) (mkTriggeredHoleName pfx sfx)
+    ]
+
+
+-- Generators
+-------------
+
+genTriggerPolicy :: QC.Gen TriggerPolicy
+genTriggerPolicy =
+  QC.oneof
+    [ pure TriggerAll
+    , pure TriggerNone
+    , TriggerPrefix <$> genValidPrefix
+    ]
+
+genValidPrefix :: QC.Gen Text
+genValidPrefix = do
+  c0 <- QC.elements ['a' .. 'z']
+  rest <- QC.listOf genIdentifierContinueChar
+  pure (T.pack (c0 : rest))
+
+genValidSuffix :: QC.Gen Text
+genValidSuffix =
+  T.pack <$> QC.listOf genIdentifierContinueChar
+
+genDistinctSuffixPair :: QC.Gen (Text, Text)
+genDistinctSuffixPair =
+  QC.suchThat
+    ((,) <$> genValidSuffix <*> genValidSuffix)
+    (uncurry (/=))
+
+genHoleName :: QC.Gen Text
+genHoleName =
+  QC.oneof
+    [ pure "_"
+    , mkTriggeredHoleName <$> genValidPrefix <*> genValidSuffix
+    , T.pack <$> QC.listOf1 QC.arbitraryASCIIChar
+    ]
+
+genIdentifierContinueChar :: QC.Gen Char
+genIdentifierContinueChar =
+  QC.frequency
+    [ (10, QC.elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9']))
+    , (1, pure '_')
+    , (1, pure '\'')
+    ]

--- a/spec/GHC/Plugin/OllamaHoles/Trigger/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Trigger/Spec.hs
@@ -99,7 +99,7 @@ matchingTests =
   testGroup "matching"
     [ testCase "TriggerAll always matches" $
         matchTriggerPolicy TriggerAll "_anything"
-          @?= Just (TriggerMatch "_anything" "_anything")
+          @?= Just (TriggerMatch "_anything" Nothing)
 
     , testCase "TriggerNone never matches" $
         matchTriggerPolicy TriggerNone "_anything"
@@ -107,23 +107,23 @@ matchingTests =
 
     , testCase "prefix match succeeds on exact prefix hole" $
         matchTriggerPolicy (TriggerPrefix "foo") "_foo"
-          @?= Just (TriggerMatch "_foo" "")
+          @?= Just (TriggerMatch "_foo" (Just ""))
 
     , testCase "prefix match succeeds with numeric suffix" $
         matchTriggerPolicy (TriggerPrefix "foo") "_foo1"
-          @?= Just (TriggerMatch "_foo1" "1")
+          @?= Just (TriggerMatch "_foo1" (Just "1"))
 
     , testCase "prefix match succeeds with alphabetic suffix" $
         matchTriggerPolicy (TriggerPrefix "foo") "_foodefault"
-          @?= Just (TriggerMatch "_foodefault" "default")
+          @?= Just (TriggerMatch "_foodefault" (Just "default"))
 
     , testCase "prefix match succeeds with underscore in suffix" $
         matchTriggerPolicy (TriggerPrefix "foo") "_foo_bar"
-          @?= Just (TriggerMatch "_foo_bar" "_bar")
+          @?= Just (TriggerMatch "_foo_bar" (Just "_bar"))
 
     , testCase "prefix match succeeds with apostrophe in suffix" $
         matchTriggerPolicy (TriggerPrefix "foo") "_foo'"
-          @?= Just (TriggerMatch "_foo'" "'")
+          @?= Just (TriggerMatch "_foo'" (Just "'"))
 
     , testCase "prefix match rejects missing leading underscore" $
         matchTriggerPolicy (TriggerPrefix "foo") "foo"
@@ -204,7 +204,7 @@ propertyTests =
         QC.forAll genValidPrefix $ \pfx ->
         QC.forAll genValidSuffix $ \sfx ->
           matchTriggerPolicy (TriggerPrefix pfx) (mkTriggeredHoleName pfx sfx)
-            === Just (TriggerMatch (mkTriggeredHoleName pfx sfx) sfx)
+            === Just (TriggerMatch (mkTriggeredHoleName pfx sfx) (Just sfx))
 
     , QC.testProperty "mkTriggeredHoleName distinguishes distinct suffixes" $
         QC.forAll genValidPrefix $ \pfx ->
@@ -217,7 +217,7 @@ propertyTests =
 
     , QC.testProperty "TriggerAll always matches any generated hole name" $
         QC.forAll genHoleName $ \nm ->
-          matchTriggerPolicy TriggerAll nm === Just (TriggerMatch nm nm)
+          matchTriggerPolicy TriggerAll nm === Just (TriggerMatch nm Nothing)
 
     , QC.testProperty "valid prefix policies parse successfully" $
         QC.forAll genValidPrefix $ \pfx ->

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -10,6 +10,7 @@ import qualified GHC.Plugin.OllamaHoles.Template.Load.Spec as LoadSpec
 import qualified GHC.Plugin.OllamaHoles.Template.Expand.Spec as ExpandSpec
 import qualified GHC.Plugin.OllamaHoles.Options.Spec as OptionsSpec
 import qualified GHC.Plugin.OllamaHoles.Logger.Spec as LoggerSpec
+import qualified GHC.Plugin.OllamaHoles.Trigger.Spec as TriggerSpec
 
 main :: IO ()
 main = defaultMain $
@@ -23,4 +24,5 @@ main = defaultMain $
         , ExpandSpec.tests
         , OptionsSpec.tests
         , LoggerSpec.tests
+        , TriggerSpec.tests
         ]

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -116,13 +116,14 @@ data PluginError
 
 isSilentError :: PluginError -> Bool
 isSilentError = \case
-  OptionParseError         _ -> True -- \
-  UnknownOptionError       _ -> True --  | These are initialization errors, and
-  TemplateSpecError        _ -> True --  | are printed by printRenderedError.
-  TemplateParseError       _ -> True -- /
-  TypedHoleNotFound        _ -> True -- This just means there are no typed holes.
-  HoleNameDoesNotMatchPolicy -> True -- The hole exists but doesn't match the trigger.
-  _                          -> False
+  OptionParseError           _ -> True -- \
+  UnknownOptionError         _ -> True --  | These are initialization errors, and
+  TemplateSpecError          _ -> True --  | are printed by printRenderedError.
+  TemplateParseError         _ -> True -- /
+  TypedHoleNotFound          _ -> True -- This just means there are no typed holes.
+  HoleMissingTriggerName       -> True
+  HoleNameDoesNotMatchPolicy _ -> True -- The hole exists but doesn't match the trigger.
+  _                            -> False
 
 renderPluginError :: PluginError -> Text
 renderPluginError = \case
@@ -229,27 +230,30 @@ tryFitPluginLLM
 tryFitPluginLLM ref typedHole fits = do
   st <- readTcRef ref >>= liftEither
   debugMsg st $ "running with flags\n" <> T.pack (show $ commandOptions st)
-  checkModel st
 
-  -- Check the trigger policy to see if this should run at all.
-  let tpol = trigger_policy $ commandOptions st
-  case holeTriggerName typedHole of
-    Nothing -> throwError HoleMissingTriggerName
-    Just holeName -> if shouldTriggerHole tpol holeName
-      then pure ()
-      else throwError $ HoleNameDoesNotMatchPolicy holeName
-
-  debugMsg st "Hole Found"
   withTypedHole typedHole $ \hole -> do
+    let tpol = trigger_policy $ commandOptions st
+    holeName <- case holeTriggerName hole of
+        Nothing -> throwError HoleMissingTriggerName
+        Just ok -> pure ok
+
+    -- Does this hole match the trigger?
+    unless (shouldTriggerHole tpol holeName) $
+      throwError (HoleNameDoesNotMatchPolicy holeName)
+    debugMsg st "Hole Found"
+
+    -- Does the specified model exist?
+    checkModel st
+
     prompt <- prepareHoleFitPrompt st typedHole fits
     debugMsg st $ "prompt:\n" <> prompt
+
     rsp <- submitRequest st prompt
     lift $ extractHoleFitsFromResponse st prompt rsp typedHole hole
 
-holeTriggerName :: TypedHole -> Maybe Text
-holeTriggerName th = do
-  h <- th_hole th
-  pure . T.pack . occNameString . rdrNameOcc $ hole_occ h
+holeTriggerName :: Hole -> Maybe Text
+holeTriggerName =
+  pure . T.pack . occNameString . rdrNameOcc . hole_occ
 
 -- | Ensure that the specified model exists.
 checkModel :: PluginState -> ExceptT PluginError TcM ()

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -116,12 +116,13 @@ data PluginError
 
 isSilentError :: PluginError -> Bool
 isSilentError = \case
-  OptionParseError   _ -> True -- \
-  UnknownOptionError _ -> True --  | These are initialization errors, and
-  TemplateSpecError  _ -> True --  | are printed by printRenderedError.
-  TemplateParseError _ -> True -- /
-  TypedHoleNotFound  _ -> True -- This just means there are no typed holes.
-  _                    -> False
+  OptionParseError         _ -> True -- \
+  UnknownOptionError       _ -> True --  | These are initialization errors, and
+  TemplateSpecError        _ -> True --  | are printed by printRenderedError.
+  TemplateParseError       _ -> True -- /
+  TypedHoleNotFound        _ -> True -- This just means there are no typed holes.
+  HoleNameDoesNotMatchPolicy -> True -- The hole exists but doesn't match the trigger.
+  _                          -> False
 
 renderPluginError :: PluginError -> Text
 renderPluginError = \case

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -121,7 +121,6 @@ isSilentError = \case
   TemplateSpecError          _ -> True --  | are printed by printRenderedError.
   TemplateParseError         _ -> True -- /
   TypedHoleNotFound          _ -> True -- This just means there are no typed holes.
-  HoleMissingTriggerName       -> True
   HoleNameDoesNotMatchPolicy _ -> True -- The hole exists but doesn't match the trigger.
   _                            -> False
 
@@ -166,6 +165,9 @@ renderPluginError = \case
 
   ResponseFailed msg ->
     "backend request failed: " <> msg
+
+  HoleNameDoesNotMatchPolicy holeName ->
+    "skipping " <> holeName <> " because it does not match the configured trigger policy"
   where
     renderToken :: Token -> Text
     renderToken = \case
@@ -233,9 +235,7 @@ tryFitPluginLLM ref typedHole fits = do
 
   withTypedHole typedHole $ \hole -> do
     let tpol = trigger_policy $ commandOptions st
-    holeName <- case holeTriggerName hole of
-        Nothing -> throwError HoleMissingTriggerName
-        Just ok -> pure ok
+        holeName = holeTriggerName hole
 
     -- Does this hole match the trigger?
     unless (shouldTriggerHole tpol holeName) $
@@ -251,9 +251,9 @@ tryFitPluginLLM ref typedHole fits = do
     rsp <- submitRequest st prompt
     lift $ extractHoleFitsFromResponse st prompt rsp typedHole hole
 
-holeTriggerName :: Hole -> Maybe Text
+holeTriggerName :: Hole -> Text
 holeTriggerName =
-  pure . T.pack . occNameString . rdrNameOcc . hole_occ
+  T.pack . occNameString . rdrNameOcc . hole_occ
 
 -- | Ensure that the specified model exists.
 checkModel :: PluginState -> ExceptT PluginError TcM ()

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -59,6 +59,7 @@ import GHC.Plugin.OllamaHoles.Prompt
 import GHC.Plugin.OllamaHoles.Logger qualified as Log
 import GHC.Plugin.OllamaHoles.Candidate
 import GHC.Plugin.OllamaHoles.Template
+import GHC.Plugin.OllamaHoles.Trigger
 
 
 
@@ -110,6 +111,8 @@ data PluginError
   | ModelNotFound Text [Text] BackendSlug
   | TypedHoleNotFound TypedHole
   | ResponseFailed Text
+  | HoleMissingTriggerName
+  | HoleNameDoesNotMatchPolicy Text
 
 isSilentError :: PluginError -> Bool
 isSilentError = \case
@@ -226,12 +229,26 @@ tryFitPluginLLM ref typedHole fits = do
   st <- readTcRef ref >>= liftEither
   debugMsg st $ "running with flags\n" <> T.pack (show $ commandOptions st)
   checkModel st
+
+  -- Check the trigger policy to see if this should run at all.
+  let tpol = trigger_policy $ commandOptions st
+  case holeTriggerName typedHole of
+    Nothing -> throwError HoleMissingTriggerName
+    Just holeName -> if shouldTriggerHole tpol holeName
+      then pure ()
+      else throwError $ HoleNameDoesNotMatchPolicy holeName
+
   debugMsg st "Hole Found"
   withTypedHole typedHole $ \hole -> do
     prompt <- prepareHoleFitPrompt st typedHole fits
     debugMsg st $ "prompt:\n" <> prompt
     rsp <- submitRequest st prompt
     lift $ extractHoleFitsFromResponse st prompt rsp typedHole hole
+
+holeTriggerName :: TypedHole -> Maybe Text
+holeTriggerName th = do
+  h <- th_hole th
+  pure . T.pack . occNameString . rdrNameOcc $ hole_occ h
 
 -- | Ensure that the specified model exists.
 checkModel :: PluginState -> ExceptT PluginError TcM ()

--- a/src/GHC/Plugin/OllamaHoles/Options.hs
+++ b/src/GHC/Plugin/OllamaHoles/Options.hs
@@ -20,6 +20,12 @@ import Text.Read (readMaybe)
 
 import GHC.Plugin.OllamaHoles.Logger (LogMode(..))
 import GHC.Plugin.OllamaHoles.Backend (BackendSlug(..), parseBackendSlug)
+import GHC.Plugin.OllamaHoles.Trigger
+  ( TriggerPolicy(..)
+  , TriggerPolicyError(..)
+  , defaultTriggerPolicy
+  , parseTriggerPolicy
+  )
 
 
 
@@ -45,6 +51,7 @@ data Flags = Flags
     , template_search_dir :: FilePath
     , log_mode            :: Maybe LogMode
     , log_dir             :: Maybe FilePath
+    , trigger_policy      :: TriggerPolicy
     } deriving (Eq, Show)
 
 -- | Default flags for the plugin
@@ -63,6 +70,7 @@ defaultFlags = Flags
     , template_search_dir = "."
     , log_mode            = Nothing
     , log_dir             = Nothing
+    , trigger_policy      = defaultTriggerPolicy
     }
 
 
@@ -108,6 +116,7 @@ data Flag
     | SetTemplateDir Text
     | SetLogMode Text
     | SetLogDir Text
+    | SetTriggerPolicy Text
     deriving (Eq, Show)
 
 parse :: Token -> Either OptError Flag
@@ -126,6 +135,7 @@ parse token = case token of
         "template-dir"    -> Left (MissingValue "template-dir")
         "log"             -> Left (MissingValue "log")
         "log-dir"         -> Left (MissingValue "log-dir")
+        "trigger"         -> Left (MissingValue "trigger")
         _                 -> Right (NoOp token)
 
     ValueToken key val -> case key of
@@ -140,6 +150,7 @@ parse token = case token of
         "template-dir"    -> Right (SetTemplateDir val)
         "log"             -> Right (SetLogMode val)
         "log-dir"         -> Right (SetLogDir val)
+        "trigger"         -> Right (SetTriggerPolicy val)
         "debug"           -> Left (UnexpectedValue "debug" val)
         "include-docs"    -> Left (UnexpectedValue "include-docs" val)
         _                 -> Right (NoOp token)
@@ -207,6 +218,12 @@ interpret flag = case flag of
     SetLogDir txt -> requireNonEmpty "log-dir" txt $
         makeOk $ \fs -> fs { log_dir = Just (T.unpack txt) }
 
+    SetTriggerPolicy txt ->
+        requireNonEmpty "trigger" txt $
+          case parseTriggerPolicy txt of
+            Right pol -> makeOk $ \fs -> fs { trigger_policy = pol }
+            Left err -> Left (InvalidTriggerPolicy txt err)
+
     where
         makeOk :: (Applicative f) => (a -> a) -> f (Endo a, [b])
         makeOk x = pure (Endo x, [])
@@ -231,4 +248,5 @@ data OptError
     | InvalidJson FlagName Text String
     | InvalidEnum FlagName Text [Text]
     | InvalidBackend Text
+    | InvalidTriggerPolicy Text TriggerPolicyError
     deriving (Eq, Show)

--- a/src/GHC/Plugin/OllamaHoles/Trigger.hs
+++ b/src/GHC/Plugin/OllamaHoles/Trigger.hs
@@ -128,7 +128,7 @@ renderTriggerPolicy = \case
 --
 data TriggerMatch = TriggerMatch
     { tmHoleName :: Text
-    , tmSuffix   :: Text
+    , tmSuffix   :: Maybe Text
     } deriving (Eq, Show)
 
 shouldTriggerHole :: TriggerPolicy -> Text -> Bool
@@ -142,7 +142,7 @@ matchTriggerPolicy pol holeName = case pol of
     TriggerNone -> Nothing
     TriggerAll -> Just TriggerMatch
         { tmHoleName = holeName
-        , tmSuffix   = holeName
+        , tmSuffix   = Nothing
         }
     TriggerPrefix pfx -> matchPrefixTrigger pfx holeName
 
@@ -154,7 +154,7 @@ matchPrefixTrigger pfx holeName
             | isValidTriggerSuffix suffix ->
                 Just TriggerMatch
                     { tmHoleName = holeName
-                    , tmSuffix   = suffix
+                    , tmSuffix   = Just suffix
                     }
         _ -> Nothing
 

--- a/src/GHC/Plugin/OllamaHoles/Trigger.hs
+++ b/src/GHC/Plugin/OllamaHoles/Trigger.hs
@@ -1,0 +1,206 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
+
+module GHC.Plugin.OllamaHoles.Trigger
+    ( TriggerPolicy(..)
+    , TriggerPolicyError(..)
+    , TriggerMatch(..)
+    , defaultTriggerPolicy
+    , parseTriggerPolicy
+    , renderTriggerPolicy
+    , shouldTriggerHole
+    , matchTriggerPolicy
+    , mkTriggeredHoleName
+    ) where
+
+import Data.Char (isAlphaNum, isLower)
+import Data.Text (Text)
+import Data.Text qualified as T
+
+
+
+-- Trigger policies
+-------------------
+
+-- | A @TriggerPolicy@ determines which typed holes are
+-- submitted to the LLM.
+data TriggerPolicy
+    = TriggerAll
+    | TriggerNone
+    | TriggerPrefix Text
+    deriving (Eq, Show)
+
+defaultTriggerPolicy :: TriggerPolicy
+defaultTriggerPolicy = TriggerPrefix "llm"
+
+
+
+-- Errors
+---------
+
+data TriggerPolicyError
+    = EmptyTriggerPolicy
+    | UnknownTriggerPolicy Text
+    | MissingTriggerPrefix
+    | InvalidTriggerPrefix Text
+    deriving (Eq, Show)
+
+
+
+-- Parsing / rendering
+----------------------
+
+-- | Parse a trigger policy from command-line text.
+--
+-- Accepted forms:
+--
+--   * @"all"@
+--   * @"none"@
+--   * @"prefix:<ident>"@
+--
+-- The prefix does /not/ include the leading underscore. For example:
+--
+--   * @"prefix:llm"@ matches holes like @_llm@, @_llm1@, @_llmFoo@
+--
+-- The prefix must be a valid Haskell variable-identifier fragment after the
+-- leading underscore:
+--
+--   * non-empty
+--   * first character must be a lowercase identifier-start character
+--   * remaining characters may be identifier-continue characters
+--
+-- This parser is intentionally conservative and focuses on ordinary Haskell
+-- identifiers used for named typed holes.
+parseTriggerPolicy :: Text -> Either TriggerPolicyError TriggerPolicy
+parseTriggerPolicy raw0 =
+    let raw = T.strip raw0
+    in case raw of
+        "" ->
+            Left EmptyTriggerPolicy
+
+        "all" ->
+            Right TriggerAll
+
+        "none" ->
+            Right TriggerNone
+
+        _ -> case T.stripPrefix "prefix:" raw of
+            Just suffix
+                | T.null suffix ->
+                    Left MissingTriggerPrefix
+                | isValidTriggerPrefix suffix ->
+                    Right (TriggerPrefix suffix)
+                | otherwise ->
+                    Left (InvalidTriggerPrefix suffix)
+
+            Nothing ->
+                Left (UnknownTriggerPolicy raw)
+
+renderTriggerPolicy :: TriggerPolicy -> Text
+renderTriggerPolicy = \case
+    TriggerAll        -> "all"
+    TriggerNone       -> "none"
+    TriggerPrefix pfx -> "prefix:" <> pfx
+
+
+
+-- Matching
+-----------
+
+-- | Result of matching a hole name against a trigger policy.
+--
+-- For prefix triggers, @tmSuffix@ is the portion of the hole name after
+-- the triggering prefix, and may be the empty string.
+--
+-- Example:
+--
+--   * policy = @TriggerPrefix "foo"@
+--   * hole   = @"_foo"@
+--   * match  = @TriggerMatch "_foo" ""@
+--
+--   * policy = @TriggerPrefix "foo"@
+--   * hole   = @"_foo1"@
+--   * match  = @TriggerMatch "_foo1" "1"@
+--
+-- Keeping the empty suffix as @""@ preserves a bijection:
+--
+--   > mkTriggeredHoleName "foo" suffix == originalHoleName
+--
+data TriggerMatch = TriggerMatch
+    { tmHoleName :: Text
+    , tmSuffix   :: Text
+    } deriving (Eq, Show)
+
+shouldTriggerHole :: TriggerPolicy -> Text -> Bool
+shouldTriggerHole pol holeName =
+    case matchTriggerPolicy pol holeName of
+        Nothing -> False
+        Just _  -> True
+
+matchTriggerPolicy :: TriggerPolicy -> Text -> Maybe TriggerMatch
+matchTriggerPolicy pol holeName = case pol of
+    TriggerNone -> Nothing
+    TriggerAll -> Just TriggerMatch
+        { tmHoleName = holeName
+        , tmSuffix   = holeName
+        }
+    TriggerPrefix pfx -> matchPrefixTrigger pfx holeName
+
+matchPrefixTrigger :: Text -> Text -> Maybe TriggerMatch
+matchPrefixTrigger pfx holeName
+    | T.null pfx = Nothing
+    | otherwise = case T.stripPrefix ("_" <> pfx) holeName of
+        Just suffix
+            | isValidTriggerSuffix suffix ->
+                Just TriggerMatch
+                    { tmHoleName = holeName
+                    , tmSuffix   = suffix
+                    }
+        _ -> Nothing
+
+-- | Reconstruct a triggered hole name from a prefix and suffix.
+--
+-- This is the companion to @matchPrefixTrigger@.
+mkTriggeredHoleName :: Text -> Text -> Text
+mkTriggeredHoleName pfx suffix = "_" <> pfx <> suffix
+
+
+
+-- Identifier validity
+----------------------
+
+-- | Prefixes are the hole name without the leading underscore.
+--
+-- We require:
+--
+--   * non-empty
+--   * no leading underscore
+--   * first character is a lowercase identifier-start character
+--   * remaining characters are identifier-continue characters
+--
+isValidTriggerPrefix :: Text -> Bool
+isValidTriggerPrefix txt = case T.uncons txt of
+    Nothing -> False
+    Just (c0, rest) ->
+        isIdentifierStartNoUnderscore c0
+            && T.all isIdentifierContinue rest
+
+-- | The suffix after the prefix may be empty, or any sequence of
+-- identifier-continue characters.
+--
+-- This lets @_foo@ and @_foodefault@ remain distinct:
+--
+--   * @_foo@        has suffix @""
+--   * @_foodefault@ has suffix @"default"@
+--
+isValidTriggerSuffix :: Text -> Bool
+isValidTriggerSuffix = T.all isIdentifierContinue
+
+isIdentifierStartNoUnderscore :: Char -> Bool
+isIdentifierStartNoUnderscore c = isLower c
+
+isIdentifierContinue :: Char -> Bool
+isIdentifierContinue c =
+       isAlphaNum c
+    || c == '_'
+    || c == '\''

--- a/src/GHC/Plugin/OllamaHoles/Trigger.hs
+++ b/src/GHC/Plugin/OllamaHoles/Trigger.hs
@@ -75,15 +75,9 @@ parseTriggerPolicy :: Text -> Either TriggerPolicyError TriggerPolicy
 parseTriggerPolicy raw0 =
     let raw = T.strip raw0
     in case raw of
-        "" ->
-            Left EmptyTriggerPolicy
-
-        "all" ->
-            Right TriggerAll
-
-        "none" ->
-            Right TriggerNone
-
+        "" -> Left EmptyTriggerPolicy
+        "all" -> Right TriggerAll
+        "none" -> Right TriggerNone
         _ -> case T.stripPrefix "prefix:" raw of
             Just suffix
                 | T.null suffix ->
@@ -93,8 +87,7 @@ parseTriggerPolicy raw0 =
                 | otherwise ->
                     Left (InvalidTriggerPrefix suffix)
 
-            Nothing ->
-                Left (UnknownTriggerPolicy raw)
+            Nothing -> Left (UnknownTriggerPolicy raw)
 
 renderTriggerPolicy :: TriggerPolicy -> Text
 renderTriggerPolicy = \case


### PR DESCRIPTION
Closes https://github.com/tweag/OllamaHoles/issues/9

Invoking an LLM tends to be expensive, and we don't want to completely hijack typed holes.

This patch adds trigger policies which determine whether or not to call the LLM for a given typed hole. The available policies are:

- all: always invoke the llm
- none: never invoke the llm
- prefix: only invoke the llm if the name of the typed hole starts with a provided prefix. The default is "llm", so for example "_llm" and "_llm1" and "_llmfoo" all match, but "_foo" does not.

The policy is specified on the command line with "trigger=all", "trigger=none", or "trigger=prefix:foo". The default is "trigger=prefix:llm".