### PR TITLE
Add common extensions

### DIFF
--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -83,7 +83,11 @@ source-repository head
   location: git://github.com/Tritlo/OllamaHoles.git
 
 common warnings
-    ghc-options: -Wall
+  ghc-options: -Wall
+  default-extensions:
+    DeriveGeneric
+    LambdaCase
+    OverloadedStrings
 
 common shared-base
   default-language: GHC2021

--- a/spec/GHC/Plugin/OllamaHoles/Candidate/Compat/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Candidate/Compat/Spec.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module GHC.Plugin.OllamaHoles.Candidate.Compat.Spec (tests) where

--- a/spec/GHC/Plugin/OllamaHoles/Candidate/Normalize/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Candidate/Normalize/Spec.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module GHC.Plugin.OllamaHoles.Candidate.Normalize.Spec (tests) where

--- a/spec/GHC/Plugin/OllamaHoles/Candidate/Rewrite/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Candidate/Rewrite/Spec.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
-
 module GHC.Plugin.OllamaHoles.Candidate.Rewrite.Spec (tests) where
 
 import Data.Text (Text)

--- a/spec/GHC/Plugin/OllamaHoles/Candidate/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Candidate/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Candidate.Spec (tests) where
 
 import Data.List qualified as L

--- a/spec/GHC/Plugin/OllamaHoles/Candidate/WithRenamedExpr.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Candidate/WithRenamedExpr.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/spec/GHC/Plugin/OllamaHoles/Config/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Config/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Config.Spec (tests) where
 
 import Data.Aeson qualified as Aeson

--- a/spec/GHC/Plugin/OllamaHoles/Config/Trigger/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Config/Trigger/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Config.Trigger.Spec
   ( tests
   ) where

--- a/spec/GHC/Plugin/OllamaHoles/Data/Config/Build/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/Config/Build/Spec.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
-
 module GHC.Plugin.OllamaHoles.Data.Config.Build.Spec
   ( tests
   ) where

--- a/spec/GHC/Plugin/OllamaHoles/Data/Prefs/Parse/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/Prefs/Parse/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.Prefs.Parse.Spec (tests) where
 
 import Data.Aeson ((.=))

--- a/spec/GHC/Plugin/OllamaHoles/Data/Prefs/Types/Gen.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/Prefs/Types/Gen.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.Prefs.Types.Gen
   ( genValidTriggerPolicyText
   , genValidTriggerPolicyCase

--- a/spec/GHC/Plugin/OllamaHoles/Data/Profile/Parse/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/Profile/Parse/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.Profile.Parse.Spec (tests) where
 
 import Data.Aeson qualified as Aeson

--- a/spec/GHC/Plugin/OllamaHoles/Data/Profile/Types/Gen.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/Profile/Types/Gen.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.Profile.Types.Gen
   ( genProfileNameText
   , genProfileName

--- a/spec/GHC/Plugin/OllamaHoles/Data/Profile/Validate/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/Profile/Validate/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.Profile.Validate.Spec (tests) where
 
 import Data.Functor ((<&>))

--- a/spec/GHC/Plugin/OllamaHoles/Data/Service/Parse/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/Service/Parse/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.Service.Parse.Spec
   ( tests
   ) where

--- a/spec/GHC/Plugin/OllamaHoles/Data/Service/Types/Gen.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/Service/Types/Gen.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.Service.Types.Gen
   ( genServiceNameText
   , genHostText

--- a/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Route/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Route/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.ServiceCall.Route.Spec
   ( tests
   ) where

--- a/spec/GHC/Plugin/OllamaHoles/Logger/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Logger/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Logger.Spec (tests) where
 
 import Control.Monad (forM)

--- a/spec/GHC/Plugin/OllamaHoles/Options/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Options/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Options.Spec (tests) where
 
 import Data.Aeson (Value(..))

--- a/spec/GHC/Plugin/OllamaHoles/Template/Expand/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Template/Expand/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Template.Expand.Spec (tests) where
 
 import Data.Text qualified as T

--- a/spec/GHC/Plugin/OllamaHoles/Template/Load/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Template/Load/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Template.Load.Spec (tests) where
 
 import Data.List qualified as L

--- a/spec/GHC/Plugin/OllamaHoles/Template/Parse/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Template/Parse/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Template.Parse.Spec (tests) where
 
 import Data.Char (isAlpha, isAscii)

--- a/spec/GHC/Plugin/OllamaHoles/Trigger/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Trigger/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Trigger.Spec (tests) where
 
 import Data.Maybe (isJust, isNothing)

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE LambdaCase #-}
 
 -- | The Ollama plugin for GHC
 module GHC.Plugin.OllamaHoles where
@@ -239,6 +236,7 @@ effectiveModelOptions st serviceProf =
 
 
 
+-- TODO: need to log individual responses properly
 extractHoleFitsFromPromptResponses
   :: PluginState -> [PromptResponse] -> TypedHole -> Hole -> TcM [HoleFit]
 extractHoleFitsFromPromptResponses st resps th hole =

--- a/src/GHC/Plugin/OllamaHoles/Backend.hs
+++ b/src/GHC/Plugin/OllamaHoles/Backend.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE DeriveGeneric #-}
-
 module GHC.Plugin.OllamaHoles.Backend
   ( module GHC.Plugin.OllamaHoles.Backend.Common
   , module GHC.Plugin.OllamaHoles.Backend.Gemini

--- a/src/GHC/Plugin/OllamaHoles/Backend/Gemini.hs
+++ b/src/GHC/Plugin/OllamaHoles/Backend/Gemini.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE DeriveGeneric #-}
 
 -- | The Gemini backend
 module GHC.Plugin.OllamaHoles.Backend.Gemini

--- a/src/GHC/Plugin/OllamaHoles/Backend/Ollama.hs
+++ b/src/GHC/Plugin/OllamaHoles/Backend/Ollama.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE DeriveGeneric #-}
 
 -- | The locally hosted ollama backend
 module GHC.Plugin.OllamaHoles.Backend.Ollama

--- a/src/GHC/Plugin/OllamaHoles/Backend/OpenAI.hs
+++ b/src/GHC/Plugin/OllamaHoles/Backend/OpenAI.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE DeriveGeneric #-}
 
 -- | The OpenAI backend
 module GHC.Plugin.OllamaHoles.Backend.OpenAI

--- a/src/GHC/Plugin/OllamaHoles/Candidate.hs
+++ b/src/GHC/Plugin/OllamaHoles/Candidate.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
-
 module GHC.Plugin.OllamaHoles.Candidate where
 
 import Control.Monad (when)

--- a/src/GHC/Plugin/OllamaHoles/Candidate/Compat.hs
+++ b/src/GHC/Plugin/OllamaHoles/Candidate/Compat.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE LambdaCase #-}
 
 module GHC.Plugin.OllamaHoles.Candidate.Compat
     ( viewExpr

--- a/src/GHC/Plugin/OllamaHoles/Candidate/Rewrite.hs
+++ b/src/GHC/Plugin/OllamaHoles/Candidate/Rewrite.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module GHC.Plugin.OllamaHoles.Candidate.Rewrite

--- a/src/GHC/Plugin/OllamaHoles/Data/Config/Build.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Config/Build.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.Config.Build
   ( buildConfig
   , buildServiceMap

--- a/src/GHC/Plugin/OllamaHoles/Data/Config/Types.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Config/Types.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
-
 module GHC.Plugin.OllamaHoles.Data.Config.Types where
 
 import Data.Aeson (Value)

--- a/src/GHC/Plugin/OllamaHoles/Data/Flags.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Flags.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.Flags
   ( module GHC.Plugin.OllamaHoles.Data.Flags.Types
   , module GHC.Plugin.OllamaHoles.Data.Flags.Error

--- a/src/GHC/Plugin/OllamaHoles/Data/Flags/Parse.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Flags/Parse.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.Flags.Parse
   ( parseFlags
   ) where

--- a/src/GHC/Plugin/OllamaHoles/Data/Flags/Types.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Flags/Types.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
-
 module GHC.Plugin.OllamaHoles.Data.Flags.Types
   ( Flags(..)
   , FlagToken(..)

--- a/src/GHC/Plugin/OllamaHoles/Data/Prefs/Parse.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Prefs/Parse.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.Prefs.Parse
   ( parsePreferencesToml
   , TomlParseError(..)

--- a/src/GHC/Plugin/OllamaHoles/Data/Prefs/Types.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Prefs/Types.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
-
 module GHC.Plugin.OllamaHoles.Data.Prefs.Types where
 
 import GHC.Generics (Generic)

--- a/src/GHC/Plugin/OllamaHoles/Data/Profile/Parse.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Profile/Parse.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module GHC.Plugin.OllamaHoles.Data.Profile.Parse
   ( tomlProfile

--- a/src/GHC/Plugin/OllamaHoles/Data/Profile/Types.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Profile/Types.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
-
 module GHC.Plugin.OllamaHoles.Data.Profile.Types where
 
 import Data.Aeson (Value)

--- a/src/GHC/Plugin/OllamaHoles/Data/Service/Parse.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Service/Parse.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module GHC.Plugin.OllamaHoles.Data.Service.Parse

--- a/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Error.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Error.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.ServiceCall.Error where
 
 import Data.Text (Text)

--- a/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.ServiceCall.Submit
   ( submitServiceCall
   ) where

--- a/src/GHC/Plugin/OllamaHoles/Data/Trigger/Match.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Trigger/Match.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.Trigger.Match
   ( shouldTriggerHole
   , matchTriggerPolicy

--- a/src/GHC/Plugin/OllamaHoles/Data/Trigger/Parse.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Trigger/Parse.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Data.Trigger.Parse
   ( parseTriggerPolicy
   ) where

--- a/src/GHC/Plugin/OllamaHoles/Data/Trigger/Types.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Trigger/Types.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
-
 module GHC.Plugin.OllamaHoles.Data.Trigger.Types
   ( TriggerPolicy(..)
   , defaultTriggerPolicy

--- a/src/GHC/Plugin/OllamaHoles/Error.hs
+++ b/src/GHC/Plugin/OllamaHoles/Error.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Error where
 
 import Data.Text (Text)

--- a/src/GHC/Plugin/OllamaHoles/Flags.hs
+++ b/src/GHC/Plugin/OllamaHoles/Flags.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Flags where
 
 import GHC.Plugin.OllamaHoles.Backend

--- a/src/GHC/Plugin/OllamaHoles/Logger.hs
+++ b/src/GHC/Plugin/OllamaHoles/Logger.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Logger
     ( Logger()
     , LogMode(..)

--- a/src/GHC/Plugin/OllamaHoles/Prompt.hs
+++ b/src/GHC/Plugin/OllamaHoles/Prompt.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module GHC.Plugin.OllamaHoles.Prompt
     ( PromptContext(..)

--- a/src/GHC/Plugin/OllamaHoles/Template.hs
+++ b/src/GHC/Plugin/OllamaHoles/Template.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module GHC.Plugin.OllamaHoles.Template
     ( Template(..)
     , TemplateExpr(..)

--- a/src/GHC/Plugin/OllamaHoles/Trigger.hs
+++ b/src/GHC/Plugin/OllamaHoles/Trigger.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
-
 module GHC.Plugin.OllamaHoles.Trigger
     ( mkTriggeredHoleName
     ) where


### PR DESCRIPTION
Adds a few default extensions to the cabal file: OverloadedStrings, LambdaCase, and DeriveGeneric. These are used in a lot of places and are harmless.