### PR TITLE
Refactor ServiceCall

### DIFF
--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -242,7 +242,6 @@ test-suite ollama-holes-spec
     , GHC.Plugin.OllamaHoles.Candidate.WithRenamedExpr
     , GHC.Plugin.OllamaHoles.Logger.Spec
     , GHC.Plugin.OllamaHoles.Options.Spec
-    , GHC.Plugin.OllamaHoles.Data.ServiceCall.Route.Spec
     , GHC.Plugin.OllamaHoles.Data.Spec
     , GHC.Plugin.OllamaHoles.Data.Config.Types.Gen
     , GHC.Plugin.OllamaHoles.Data.Config.Error.Predicate
@@ -269,6 +268,11 @@ test-suite ollama-holes-spec
     , GHC.Plugin.OllamaHoles.Data.Prefs.Spec
     , GHC.Plugin.OllamaHoles.Data.Prefs.Types.Gen
     , GHC.Plugin.OllamaHoles.Data.Prefs.Parse.Spec
+    , GHC.Plugin.OllamaHoles.Data.ServiceCall.TestM
+    , GHC.Plugin.OllamaHoles.Data.ServiceCall.Spec
+    , GHC.Plugin.OllamaHoles.Data.ServiceCall.Types.Gen
+    , GHC.Plugin.OllamaHoles.Data.ServiceCall.Route.Spec
+    , GHC.Plugin.OllamaHoles.Data.ServiceCall.Submit.Spec
     , Toml.TestHelper
   build-depends:
       base

--- a/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Route/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Route/Spec.hs
@@ -3,18 +3,16 @@ module GHC.Plugin.OllamaHoles.Data.ServiceCall.Route.Spec
   ) where
 
 import Control.Monad.Except
-import Data.Aeson (Value(..))
 import Data.Functor ((<&>))
-import Data.List (nub)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as M
 import Data.Text (Text)
-import Data.Text qualified as T
 
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck qualified as QC
 
+import GHC.Plugin.OllamaHoles.Backend
 import GHC.Plugin.OllamaHoles.Data.Config
 import GHC.Plugin.OllamaHoles.Data.Profile
 import GHC.Plugin.OllamaHoles.Data.Service
@@ -22,7 +20,6 @@ import GHC.Plugin.OllamaHoles.Data.ServiceCall.Error
 import GHC.Plugin.OllamaHoles.Data.ServiceCall.Route
 import GHC.Plugin.OllamaHoles.Data.ServiceCall.TestM
 import GHC.Plugin.OllamaHoles.Data.ServiceCall.Types
-import GHC.Plugin.OllamaHoles.Data.Template
 import GHC.Plugin.OllamaHoles.Data.Trigger
 
 import GHC.Plugin.OllamaHoles.Data.ServiceCall.Types.Gen
@@ -81,10 +78,9 @@ tests_prepareServiceCalls_prop = testGroup "prepareServiceCalls (prop)"
             , simpleProfile = profA
             }
 
-          env = ServiceCallTestEnv
-            { testModels = M.fromList
-              [ (ServiceName "svc-a", Just [ModelName "model-a"])
-              ]
+          env =  ServiceCallTestEnv
+            { testOllamaModels = Just [ModelName "model-a"]
+            , testOpenAIModels = Nothing
             , testResponses = M.empty
             }
 
@@ -127,14 +123,12 @@ tests_prepareServiceCalls_prop = testGroup "prepareServiceCalls (prop)"
             , cfgExtras = Just (ConfigOverride emptyOverrides)
             }
 
-          env =
-            ServiceCallTestEnv
-              { testModels = M.fromList
-                [ ( indexedServiceName i, Just [indexedModelName i] )
-                | i <- indices
-                ]
-              , testResponses = M.empty
-              }
+          env = ServiceCallTestEnv
+            { testOllamaModels = Just
+                [ indexedModelName i | i <- indices ]
+            , testOpenAIModels = Nothing
+            , testResponses = M.empty
+            }
 
           expected =
             Right CheckedServiceCalls
@@ -165,11 +159,10 @@ tests_prepareServiceCalls_unit_success =
       , "_llm"
       )
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-a", Just [ModelName "model-a"])
-          ]
-        , testResponses = M.empty
-        }
+      { testOllamaModels = Just [ModelName "model-a"]
+      , testOpenAIModels = Nothing
+      , testResponses = M.empty
+      }
     , CheckedServiceCalls
         { checkedAccepted =
           [ ServiceCall
@@ -190,11 +183,10 @@ tests_prepareServiceCalls_unit_success =
       , "_anything"
       )
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-a", Just [ModelName "model-a"])
-          ]
-        , testResponses = M.empty
-        }
+      { testOllamaModels = Just [ModelName "model-a"]
+      , testOpenAIModels = Nothing
+      , testResponses = M.empty
+      }
     , CheckedServiceCalls
         { checkedAccepted =
           [ ServiceCall
@@ -230,11 +222,10 @@ tests_prepareServiceCalls_unit_success =
       , "_anything"
       )
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-overlay", Just [ModelName "model-overlay"])
-          ]
-        , testResponses = M.empty
-        }
+      { testOllamaModels = Just [ModelName "model-overlay"]
+      , testOpenAIModels = Nothing
+      , testResponses = M.empty
+      }
     , CheckedServiceCalls
         { checkedAccepted =
           [ ServiceCall
@@ -283,12 +274,13 @@ tests_prepareServiceCalls_unit_success =
       , "_fan"
       )
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-a", Just [ModelName "model-a"])
-          , (ServiceName "svc-b", Just [ModelName "model-b"])
-          ]
-        , testResponses = M.empty
-        }
+      { testOllamaModels = Just
+        [ ModelName "model-a"
+        , ModelName "model-b"
+        ]
+      , testOpenAIModels = Nothing
+      , testResponses = M.empty
+      }
     , CheckedServiceCalls
         { checkedAccepted =
           [ ServiceCall
@@ -341,25 +333,96 @@ tests_prepareServiceCalls_unit_success =
       , "_anything"
       )
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-a", Just [ModelName "model-a"])
-          , (ServiceName "svc-b", Just [ModelName "not-model-b"])
-          ]
+      { testOllamaModels = Just [ModelName "model-a"]
+      , testOpenAIModels = Just [ModelName "not-model-b"]
+      , testResponses = M.empty
+      }
+  , CheckedServiceCalls
+    { checkedAccepted =
+      [ ServiceCall
+          { callService = svcA
+          , callProfile = profA
+          }
+      ]
+    , checkedWarnings =
+      [ SkippedServiceMissingModel
+          (ServiceName "svc-b")
+          (ModelName "model-b")
+          [ModelName "model-a"]
+      ]
+    }
+  )
+
+  , ( "normal route uses configured service when overlay has same service name"
+    , ( ConfigFancy FancyConfig
+          { cfgServices = M.fromList
+            [ ( ServiceName "shared"
+              , Service
+                  { svcName = ServiceName "shared"
+                  , svcConfig = SvcOllama (OllamaConfig Nothing)
+                  }
+              )
+            ]
+          , cfgProfiles = M.fromList
+            [ ( ProfileName "normal"
+              , Profile
+                  { profName = ProfileName "normal"
+                  , profTrigger = TriggerPrefix "llm"
+                  , profKind = ProfService ServiceProf
+                    { profService = ServiceName "shared"
+                    , profModel = ModelName "normal-model"
+                    , profTemplate = Nothing
+                    , profModelOptions = Nothing
+                    , profNumExpr = Nothing
+                    , profIncludeDocs = Nothing
+                    }
+                  }
+              )
+            ]
+          , cfgExtras = Just $
+              ConfigOverlay SimpleConfig
+                { simpleTrigger = TriggerPrefix "overlay"
+                , simpleService = Service
+                  { svcName = ServiceName "shared"
+                  , svcConfig = SvcOpenAI $ OpenAIConfig
+                      "https://example.invalid/v1"
+                      "TEST_API_KEY"
+                  }
+                , simpleProfile = ServiceProf
+                  { profService = ServiceName "shared"
+                  , profModel = ModelName "overlay-model"
+                  , profTemplate = Nothing
+                  , profModelOptions = Nothing
+                  , profNumExpr = Nothing
+                  , profIncludeDocs = Nothing
+                  }
+                }
+          }
+      , "_llm"
+      )
+    , ServiceCallTestEnv
+        { testOllamaModels = Just [ModelName "normal-model"]
+        , testOpenAIModels = Just [ModelName "overlay-model"]
         , testResponses = M.empty
         }
     , CheckedServiceCalls
         { checkedAccepted =
           [ ServiceCall
-              { callService = svcA
-              , callProfile = profA
+              { callService = Service
+                { svcName = ServiceName "shared"
+                , svcConfig = SvcOllama (OllamaConfig Nothing)
+                }
+              , callProfile = ServiceProf
+                { profService = ServiceName "shared"
+                , profModel = ModelName "normal-model"
+                , profTemplate = Nothing
+                , profModelOptions = Nothing
+                , profNumExpr = Nothing
+                , profIncludeDocs = Nothing
+                }
               }
           ]
-        , checkedWarnings =
-          [ SkippedServiceMissingModel
-              (ServiceName "svc-b")
-              (ModelName "model-b")
-              [ModelName "not-model-b"]
-          ]
+        , checkedWarnings = []
         }
     )
   ]
@@ -376,11 +439,10 @@ tests_prepareServiceCalls_unit_failure =
       , "_other"
       )
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-a", Just [ModelName "model-a"])
-          ]
-        , testResponses = M.empty
-        }
+      { testOllamaModels = Just [ModelName "model-a"]
+      , testOpenAIModels = Nothing
+      , testResponses = M.empty
+      }
     )
 
   , ( "TriggerNone in simple config never routes"
@@ -392,11 +454,10 @@ tests_prepareServiceCalls_unit_failure =
       , "_llm"
       )
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-a", Just [ModelName "model-a"])
-          ]
-        , testResponses = M.empty
-        }
+      { testOllamaModels = Just [ModelName "model-a"]
+      , testOpenAIModels = Nothing
+      , testResponses = M.empty
+      }
     )
 
   , ( "fancy config reports ambiguous matching profiles"
@@ -426,7 +487,8 @@ tests_prepareServiceCalls_unit_failure =
       , "_anything"
       )
     , ServiceCallTestEnv
-        { testModels = M.empty
+        { testOllamaModels = Nothing
+        , testOpenAIModels = Nothing
         , testResponses = M.empty
         }
     )
@@ -450,7 +512,8 @@ tests_prepareServiceCalls_unit_failure =
       , "_anything"
       )
     , ServiceCallTestEnv
-        { testModels = M.empty
+        { testOllamaModels = Nothing
+        , testOpenAIModels = Nothing
         , testResponses = M.empty
         }
     )
@@ -475,7 +538,8 @@ tests_prepareServiceCalls_unit_failure =
       , "_anything"
       )
     , ServiceCallTestEnv
-        { testModels = M.empty
+        { testOllamaModels = Nothing
+        , testOpenAIModels = Nothing
         , testResponses = M.empty
         }
     )
@@ -489,9 +553,8 @@ tests_prepareServiceCalls_unit_failure =
       , "_anything"
       )
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-a", Nothing)
-          ]
+        { testOllamaModels = Nothing
+        , testOpenAIModels = Nothing
         , testResponses = M.empty
         }
     )
@@ -505,10 +568,9 @@ tests_prepareServiceCalls_unit_failure =
       , "_anything"
       )
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-a", Just [ModelName "other-model"])
-          ]
-        , testResponses = M.empty
-        }
+      { testOllamaModels = Just [ModelName "other-model"]
+      , testOpenAIModels = Nothing
+      , testResponses = M.empty
+      }
     )
   ]

--- a/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Route/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Route/Spec.hs
@@ -2,561 +2,513 @@ module GHC.Plugin.OllamaHoles.Data.ServiceCall.Route.Spec
   ( tests
   ) where
 
+import Control.Monad.Except
 import Data.Aeson (Value(..))
+import Data.Functor ((<&>))
 import Data.List (nub)
+import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as M
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.List.NonEmpty (NonEmpty)
-import Data.List.NonEmpty qualified as NE
 
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck qualified as QC
 
-import GHC.Plugin.OllamaHoles.Backend
 import GHC.Plugin.OllamaHoles.Data.Config
 import GHC.Plugin.OllamaHoles.Data.Profile
 import GHC.Plugin.OllamaHoles.Data.Service
 import GHC.Plugin.OllamaHoles.Data.ServiceCall.Error
 import GHC.Plugin.OllamaHoles.Data.ServiceCall.Route
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.TestM
 import GHC.Plugin.OllamaHoles.Data.ServiceCall.Types
-import GHC.Plugin.OllamaHoles.Data.Trigger
 import GHC.Plugin.OllamaHoles.Data.Template
+import GHC.Plugin.OllamaHoles.Data.Trigger
+
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.Types.Gen
+
 
 
 tests :: TestTree
-tests =
-  testGroup "GHC.Plugin.OllamaHoles.Data.ServiceCall.Route"
-    [ unitTests
-    , propertyTests
-    ]
+tests = testGroup "GHC.Plugin.OllamaHoles.Data.ServiceCall.Route"
+  [ tests_prepareServiceCalls_unit
+  , tests_prepareServiceCalls_prop
+  ]
 
 
-unitTests :: TestTree
-unitTests =
-  testGroup "unit tests"
-    [ testCase "simple config returns one service call when trigger matches" $
-        routeServiceCalls
-          (ConfigSimple (simpleConfig (TriggerPrefix "llm") svcA profA))
-          (holeName "_llm")
-          @?= Right (Just [callA])
 
-    , testCase "simple config returns Nothing when trigger does not match" $
-        routeServiceCalls
-          (ConfigSimple (simpleConfig (TriggerPrefix "llm") svcA profA))
-          (holeName "_other")
-          @?= Right Nothing
+run_prepareServiceCalls
+  :: Config
+  -> Text
+  -> ServiceCallTestEnv
+  -> Either ServiceCallError CheckedServiceCalls
+run_prepareServiceCalls config holeName env =
+  runTestM $
+    runExceptT $
+      prepareServiceCalls
+        (listModelsFromEnv env)
+        config
+        holeName
 
-    , testCase "TriggerNone in simple config never routes" $
-        routeServiceCalls
-          (ConfigSimple (simpleConfig TriggerNone svcA profA))
-          (holeName "_llm")
-          @?= Right Nothing
+tests_prepareServiceCalls_unit :: TestTree
+tests_prepareServiceCalls_unit = testGroup "prepareServiceCalls (unit)"
+  [ testGroup "success" $
+      tests_prepareServiceCalls_unit_success <&>
+        \(name, (config, holeName), env, expected) ->
+          testCase name $
+            run_prepareServiceCalls config holeName env @?= Right expected
 
-    , testCase "TriggerAll in simple config always routes" $
-        routeServiceCalls
-          (ConfigSimple (simpleConfig TriggerAll svcA profA))
-          (holeName "_anything")
-          @?= Right (Just [callA])
+  , testGroup "failure" $
+      tests_prepareServiceCalls_unit_failure <&>
+        \(name, (config, holeName), env) ->
+          testCase name $
+            case run_prepareServiceCalls config holeName env of
+              Left _ -> pure ()
 
-    , testCase "fancy overlay takes priority over matching config profile" $
+              Right ok -> assertFailure $
+                "expected failed service-call preparation but got: " <> show ok
+  ]
+
+tests_prepareServiceCalls_prop :: TestTree
+tests_prepareServiceCalls_prop = testGroup "prepareServiceCalls (prop)"
+  [ QC.testProperty "simple config agrees with shouldTriggerHole when model is available" $
+      QC.forAll genTriggerPolicy $ \trigger ->
+      QC.forAll genHoleName $ \hn ->
         let
-          overlay =
-            simpleConfig TriggerAll svcOverlay profOverlay
+          config = ConfigSimple SimpleConfig
+            { simpleTrigger = trigger
+            , simpleService = svcA
+            , simpleProfile = profA
+            }
 
-          profile =
-            serviceProfile "p" TriggerAll profA
+          env = ServiceCallTestEnv
+            { testModels = M.fromList
+              [ (ServiceName "svc-a", Just [ModelName "model-a"])
+              ]
+            , testResponses = M.empty
+            }
 
-          cfg =
-            fancyConfig
-              [svcA]
-              [profile]
-              (Just (ConfigOverlay overlay))
+          expected = if shouldTriggerHole trigger hn
+            then Right CheckedServiceCalls
+              { checkedAccepted =
+                [ ServiceCall
+                    { callService = svcA
+                    , callProfile = profA
+                    }
+                ]
+              , checkedWarnings = []
+              }
+            else Left $
+              ServiceCallModelError $
+                NoServiceCallsRouted hn
         in
-          routeServiceCalls cfg (holeName "_anything")
-            @?= Right (Just [callOverlay])
+          run_prepareServiceCalls config hn env QC.=== expected
 
-    , testCase "fancy override routes matching service profile" $
+  , QC.testProperty "fanout preserves child order when all models are available" $
+      QC.forAll genDistinctIndices $ \indices ->
         let
-          profile =
-            serviceProfile "p" (TriggerPrefix "llm") profA
+          services = [ indexedService i | i <- indices ]
+          children = [ indexedServiceProfile i | i <- indices ]
 
-          cfg =
-            fancyConfig
-              [svcA]
-              [profile]
-              (Just (ConfigOverride emptyOverrides))
-        in
-          routeServiceCalls cfg (holeName "_llm")
-            @?= Right (Just [callA])
+          fan = Profile
+            { profName = ProfileName "fan"
+            , profTrigger = TriggerAll
+            , profKind = ProfFanout FanoutProf
+              { profProfiles = NE.fromList
+                  [ indexedProfileName i | i <- indices ]
+              }
+            }
 
-    , testCase "fancy config returns Nothing when no profile trigger matches" $
-        let
-          profile =
-            serviceProfile "p" (TriggerPrefix "llm") profA
+          config = ConfigFancy FancyConfig
+            { cfgServices = M.fromList
+              [ (svcName svc, svc) | svc <- services ]
+            , cfgProfiles = M.fromList
+              [ (profName profile, profile) | profile <- fan : children ]
+            , cfgExtras = Just (ConfigOverride emptyOverrides)
+            }
 
-          cfg =
-            fancyConfig
-              [svcA]
-              [profile]
-              (Just (ConfigOverride emptyOverrides))
-        in
-          routeServiceCalls cfg (holeName "_other")
-            @?= Right Nothing
-
-    , testCase "fancy config reports ambiguous matching profiles" $
-        let
-          pA =
-            serviceProfile "a" TriggerAll profA
-
-          pB =
-            serviceProfile "b" TriggerAll profB
-
-          cfg =
-            fancyConfig
-              [svcA, svcB]
-              [pB, pA]
-              (Just (ConfigOverride emptyOverrides))
-        in
-          routeServiceCalls cfg (holeName "_anything")
-            @?= Left
-                  (RouteAmbiguousProfiles
-                    (holeName "_anything")
-                    [ProfileName "a", ProfileName "b"])
-
-    , testCase "fancy config reports unknown service" $
-        let
-          missingProf =
-            profA { profService = ServiceName "missing" }
-
-          profile =
-            serviceProfile "p" TriggerAll missingProf
-
-          cfg =
-            fancyConfig
-              []
-              [profile]
-              (Just (ConfigOverride emptyOverrides))
-        in
-          routeServiceCalls cfg (holeName "_anything")
-            @?= Left (RouteUnknownService (ServiceName "missing"))
-
-    , testCase "fanout expands child profiles in fanout order" $
-        let
-          childA =
-            serviceProfile "a" TriggerNone profA
-
-          childB =
-            serviceProfile "b" TriggerNone profB
-
-          fan =
-            fanoutProfile
-              "fan"
-              (TriggerPrefix "fan")
-              (NE.fromList [ProfileName "b", ProfileName "a"])
-
-          cfg =
-            fancyConfig
-              [svcA, svcB]
-              [childA, childB, fan]
-              (Just (ConfigOverride emptyOverrides))
-        in
-          routeServiceCalls cfg (holeName "_fan")
-            @?= Right (Just [callB, callA])
-
-    , testCase "fanout reports unknown child profile" $
-        let
-          fan =
-            fanoutProfile
-              "fan"
-              TriggerAll
-              (NE.fromList [ProfileName "missing"])
-
-          cfg =
-            fancyConfig
-              []
-              [fan]
-              (Just (ConfigOverride emptyOverrides))
-        in
-          routeServiceCalls cfg (holeName "_anything")
-            @?= Left (RouteUnknownProfile (ProfileName "missing"))
-
-    , testCase "override config overrides service profile fields" $
-        let
-          original =
-            profA
-              { profModel = ModelName "original-model"
-              , profTemplate = Just (TemplateFile "original.tmpl")
-              , profModelOptions = Just (String "original-options")
-              , profNumExpr = Just 1
-              , profIncludeDocs = Just False
+          env =
+            ServiceCallTestEnv
+              { testModels = M.fromList
+                [ ( indexedServiceName i, Just [indexedModelName i] )
+                | i <- indices
+                ]
+              , testResponses = M.empty
               }
 
           expected =
-            original
-              { profModel = ModelName "override-model"
-              , profTemplate = Just (TemplateFile "override.tmpl")
-              , profModelOptions = Just (String "override-options")
-              , profNumExpr = Just 99
-              , profIncludeDocs = Just True
-              }
-
-          overrides =
-            OverrideConfig
-              { overrideModelName = Just (ModelName "override-model")
-              , overrideTemplate = Just (TemplateFile "override.tmpl")
-              , overrideModelOptions = Just (String "override-options")
-              , overrideNumExpr = Just 99
-              , overrideIncludeDocs = Just True
-              }
-
-          profile =
-            serviceProfile "p" TriggerAll original
-
-          cfg =
-            fancyConfig
-              [svcA]
-              [profile]
-              (Just (ConfigOverride overrides))
-        in
-          routeServiceCalls cfg (holeName "_anything")
-            @?= Right
-                  (Just
-                    [ ServiceCall
-                        { callProfile = expected
-                        , callService = svcA
-                        }
-                    ])
-
-    , testCase "empty override preserves service profile fields" $
-        let
-          profile =
-            serviceProfile "p" TriggerAll profA
-
-          cfg =
-            fancyConfig
-              [svcA]
-              [profile]
-              (Just (ConfigOverride emptyOverrides))
-        in
-          routeServiceCalls cfg (holeName "_anything")
-            @?= Right (Just [callA])
-    ]
-
-
-propertyTests :: TestTree
-propertyTests =
-  testGroup "properties"
-    [ QC.testProperty "simple config agrees with shouldTriggerHole" $
-        QC.forAll genTriggerPolicy $ \trigger ->
-        QC.forAll genHoleName $ \hn ->
-          let
-            cfg =
-              ConfigSimple (simpleConfig trigger svcA profA)
-
-            expected =
-              if shouldTriggerHole trigger hn
-                then Just [callA]
-                else Nothing
-          in
-            routeServiceCalls cfg hn QC.=== Right expected
-
-    , QC.testProperty "fancy overlay wins whenever overlay trigger matches" $
-        QC.forAll genHoleName $ \hn ->
-          let
-            overlay =
-              simpleConfig TriggerAll svcOverlay profOverlay
-
-            profile =
-              serviceProfile "p" TriggerAll profA
-
-            cfg =
-              fancyConfig
-                [svcA]
-                [profile]
-                (Just (ConfigOverlay overlay))
-          in
-            routeServiceCalls cfg hn QC.=== Right (Just [callOverlay])
-
-    , QC.testProperty "fanout preserves child order" $
-        QC.forAll genDistinctIndices $ \indices ->
-          let
-            children =
-              [ indexedServiceProfile i
-              | i <- indices
-              ]
-
-            services =
-              [ indexedService i
-              | i <- indices
-              ]
-
-            fan =
-              fanoutProfile
-                "fan"
-                TriggerAll
-                (NE.fromList [ indexedProfileName i
+            Right CheckedServiceCalls
+              { checkedAccepted =
+                [ ServiceCall
+                    { callService = indexedService i
+                    , callProfile = indexedServiceProf i
+                    }
                 | i <- indices
-                ])
-
-            cfg =
-              fancyConfig
-                services
-                (fan : children)
-                (Just (ConfigOverride emptyOverrides))
-
-            expected =
-              [ ServiceCall
-                  { callProfile = indexedServiceProf i
-                  , callService = indexedService i
-                  }
-              | i <- indices
-              ]
-          in
-            routeServiceCalls cfg (holeName "_anything")
-              QC.=== Right (Just expected)
-
-    , QC.testProperty "empty override preserves routed service profile" $
-        QC.forAll genHoleName $ \hn ->
-          let
-            profile =
-              serviceProfile "p" TriggerAll profA
-
-            cfg =
-              fancyConfig
-                [svcA]
-                [profile]
-                (Just (ConfigOverride emptyOverrides))
-          in
-            routeServiceCalls cfg hn QC.=== Right (Just [callA])
-    ]
+                ]
+              , checkedWarnings = []
+              }
+        in
+          run_prepareServiceCalls config "_anything" env QC.=== expected
+  ]
 
 
--- Helpers
-----------
 
-simpleConfig :: TriggerPolicy -> Service -> ServiceProf -> SimpleConfig
-simpleConfig trigger svc profile =
-  SimpleConfig
-    { simpleTrigger = trigger
-    , simpleService = svc
-    , simpleProfile = profile
-    }
-
-
-fancyConfig
-  :: [Service]
-  -> [Profile]
-  -> Maybe ExtraConfig
-  -> Config
-fancyConfig services profiles extras =
-  ConfigFancy FancyConfig
-    { cfgServices =
-        M.fromList
-          [ (svcName svc, svc)
-          | svc <- services
+tests_prepareServiceCalls_unit_success
+  :: [(String, (Config, Text), ServiceCallTestEnv, CheckedServiceCalls)]
+tests_prepareServiceCalls_unit_success =
+  [ ( "simple config returns one service call when trigger matches"
+    , ( ConfigSimple SimpleConfig
+          { simpleTrigger = TriggerPrefix "llm"
+          , simpleService = svcA
+          , simpleProfile = profA
+          }
+      , "_llm"
+      )
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-a", Just [ModelName "model-a"])
           ]
-
-    , cfgProfiles =
-        M.fromList
-          [ (profName profile, profile)
-          | profile <- profiles
-          ]
-
-    , cfgExtras =
-        extras
-    }
-
-
-serviceProfile :: ProfileName -> TriggerPolicy -> ServiceProf -> Profile
-serviceProfile name trigger profile =
-  Profile
-    { profName = name
-    , profTrigger = trigger
-    , profKind = ProfService profile
-    }
-
-
-fanoutProfile :: ProfileName -> TriggerPolicy -> NonEmpty ProfileName -> Profile
-fanoutProfile name trigger children =
-  Profile
-    { profName = name
-    , profTrigger = trigger
-    , profKind = ProfFanout FanoutProf
-        { profProfiles = children
+        , testResponses = M.empty
         }
-    }
+    , CheckedServiceCalls
+        { checkedAccepted =
+          [ ServiceCall
+              { callService = svcA
+              , callProfile = profA
+              }
+          ]
+        , checkedWarnings = []
+        }
+    )
 
+  , ( "TriggerAll in simple config always routes"
+    , ( ConfigSimple SimpleConfig
+          { simpleTrigger = TriggerAll
+          , simpleService = svcA
+          , simpleProfile = profA
+          }
+      , "_anything"
+      )
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-a", Just [ModelName "model-a"])
+          ]
+        , testResponses = M.empty
+        }
+    , CheckedServiceCalls
+        { checkedAccepted =
+          [ ServiceCall
+              { callService = svcA
+              , callProfile = profA
+              }
+          ]
+        , checkedWarnings = []
+        }
+    )
 
-emptyOverrides :: OverrideConfig
-emptyOverrides =
-  OverrideConfig
-    { overrideModelName = Nothing
-    , overrideTemplate = Nothing
-    , overrideModelOptions = Nothing
-    , overrideNumExpr = Nothing
-    , overrideIncludeDocs = Nothing
-    }
+  , ( "fancy overlay takes priority over matching config profile"
+    , ( ConfigFancy FancyConfig
+          { cfgServices = M.fromList
+            [ (ServiceName "svc-a", svcA)
+            ]
+          , cfgProfiles = M.fromList
+            [ ( ProfileName "p"
+              , Profile
+                  { profName = ProfileName "p"
+                  , profTrigger = TriggerAll
+                  , profKind = ProfService profA
+                  }
+              )
+            ]
+          , cfgExtras = Just $
+              ConfigOverlay SimpleConfig
+                { simpleTrigger = TriggerAll
+                , simpleService = svcOverlay
+                , simpleProfile = profOverlay
+                }
+          }
+      , "_anything"
+      )
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-overlay", Just [ModelName "model-overlay"])
+          ]
+        , testResponses = M.empty
+        }
+    , CheckedServiceCalls
+        { checkedAccepted =
+          [ ServiceCall
+              { callService = svcOverlay
+              , callProfile = profOverlay
+              }
+          ]
+        , checkedWarnings = []
+        }
+    )
 
+  , ( "fanout expands child profiles in fanout order"
+    , ( ConfigFancy FancyConfig
+          { cfgServices = M.fromList
+            [ (ServiceName "svc-a", svcA)
+            , (ServiceName "svc-b", svcB)
+            ]
+          , cfgProfiles = M.fromList
+            [ ( ProfileName "a"
+              , Profile
+                  { profName = ProfileName "a"
+                  , profTrigger = TriggerNone
+                  , profKind = ProfService profA
+                  }
+              )
+            , ( ProfileName "b"
+              , Profile
+                  { profName = ProfileName "b"
+                  , profTrigger = TriggerNone
+                  , profKind = ProfService profB
+                  }
+              )
+            , ( ProfileName "fan"
+              , Profile
+                  { profName = ProfileName "fan"
+                  , profTrigger = TriggerPrefix "fan"
+                  , profKind = ProfFanout FanoutProf
+                    { profProfiles =
+                        ProfileName "b" NE.:| [ProfileName "a"]
+                    }
+                  }
+              )
+            ]
+          , cfgExtras = Just (ConfigOverride emptyOverrides)
+          }
+      , "_fan"
+      )
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-a", Just [ModelName "model-a"])
+          , (ServiceName "svc-b", Just [ModelName "model-b"])
+          ]
+        , testResponses = M.empty
+        }
+    , CheckedServiceCalls
+        { checkedAccepted =
+          [ ServiceCall
+              { callService = svcB
+              , callProfile = profB
+              }
+          , ServiceCall
+              { callService = svcA
+              , callProfile = profA
+              }
+          ]
+        , checkedWarnings = []
+        }
+    )
 
-svcA :: Service
-svcA =
-  service "svc-a"
+  , ( "one missing model is warned while other routed services remain"
+    , ( ConfigFancy FancyConfig
+          { cfgServices = M.fromList
+            [ (ServiceName "svc-a", svcA)
+            , (ServiceName "svc-b", svcB)
+            ]
+          , cfgProfiles = M.fromList
+            [ ( ProfileName "a"
+              , Profile
+                  { profName = ProfileName "a"
+                  , profTrigger = TriggerNone
+                  , profKind = ProfService profA
+                  }
+              )
+            , ( ProfileName "b"
+              , Profile
+                  { profName = ProfileName "b"
+                  , profTrigger = TriggerNone
+                  , profKind = ProfService profB
+                  }
+              )
+            , ( ProfileName "fan"
+              , Profile
+                  { profName = ProfileName "fan"
+                  , profTrigger = TriggerAll
+                  , profKind = ProfFanout FanoutProf
+                    { profProfiles =
+                        ProfileName "a" NE.:| [ProfileName "b"]
+                    }
+                  }
+              )
+            ]
+          , cfgExtras = Just (ConfigOverride emptyOverrides)
+          }
+      , "_anything"
+      )
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-a", Just [ModelName "model-a"])
+          , (ServiceName "svc-b", Just [ModelName "not-model-b"])
+          ]
+        , testResponses = M.empty
+        }
+    , CheckedServiceCalls
+        { checkedAccepted =
+          [ ServiceCall
+              { callService = svcA
+              , callProfile = profA
+              }
+          ]
+        , checkedWarnings =
+          [ SkippedServiceMissingModel
+              (ServiceName "svc-b")
+              (ModelName "model-b")
+              [ModelName "not-model-b"]
+          ]
+        }
+    )
+  ]
 
+tests_prepareServiceCalls_unit_failure
+  :: [(String, (Config, Text), ServiceCallTestEnv)]
+tests_prepareServiceCalls_unit_failure =
+  [ ( "simple config returns error when trigger does not match"
+    , ( ConfigSimple SimpleConfig
+          { simpleTrigger = TriggerPrefix "llm"
+          , simpleService = svcA
+          , simpleProfile = profA
+          }
+      , "_other"
+      )
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-a", Just [ModelName "model-a"])
+          ]
+        , testResponses = M.empty
+        }
+    )
 
-svcB :: Service
-svcB =
-  service "svc-b"
+  , ( "TriggerNone in simple config never routes"
+    , ( ConfigSimple SimpleConfig
+          { simpleTrigger = TriggerNone
+          , simpleService = svcA
+          , simpleProfile = profA
+          }
+      , "_llm"
+      )
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-a", Just [ModelName "model-a"])
+          ]
+        , testResponses = M.empty
+        }
+    )
 
+  , ( "fancy config reports ambiguous matching profiles"
+    , ( ConfigFancy FancyConfig
+          { cfgServices = M.fromList
+            [ (ServiceName "svc-a", svcA)
+            , (ServiceName "svc-b", svcB)
+            ]
+          , cfgProfiles = M.fromList
+            [ ( ProfileName "a"
+              , Profile
+                  { profName = ProfileName "a"
+                  , profTrigger = TriggerAll
+                  , profKind = ProfService profA
+                  }
+              )
+            , ( ProfileName "b"
+              , Profile
+                  { profName = ProfileName "b"
+                  , profTrigger = TriggerAll
+                  , profKind = ProfService profB
+                  }
+              )
+            ]
+          , cfgExtras = Just (ConfigOverride emptyOverrides)
+          }
+      , "_anything"
+      )
+    , ServiceCallTestEnv
+        { testModels = M.empty
+        , testResponses = M.empty
+        }
+    )
 
-svcOverlay :: Service
-svcOverlay =
-  service "svc-overlay"
+  , ( "fancy config reports unknown service"
+    , ( ConfigFancy FancyConfig
+          { cfgServices = M.fromList []
+          , cfgProfiles = M.fromList
+            [ ( ProfileName "p"
+              , Profile
+                  { profName = ProfileName "p"
+                  , profTrigger = TriggerAll
+                  , profKind = ProfService profA
+                    { profService = ServiceName "missing"
+                    }
+                  }
+              )
+            ]
+          , cfgExtras = Just (ConfigOverride emptyOverrides)
+          }
+      , "_anything"
+      )
+    , ServiceCallTestEnv
+        { testModels = M.empty
+        , testResponses = M.empty
+        }
+    )
 
+  , ( "fanout reports unknown child profile"
+    , ( ConfigFancy FancyConfig
+          { cfgServices = M.fromList []
+          , cfgProfiles = M.fromList
+            [ ( ProfileName "fan"
+              , Profile
+                  { profName = ProfileName "fan"
+                  , profTrigger = TriggerAll
+                  , profKind = ProfFanout FanoutProf
+                    { profProfiles =
+                        ProfileName "missing" NE.:| []
+                    }
+                  }
+              )
+            ]
+          , cfgExtras = Just (ConfigOverride emptyOverrides)
+          }
+      , "_anything"
+      )
+    , ServiceCallTestEnv
+        { testModels = M.empty
+        , testResponses = M.empty
+        }
+    )
 
-service :: ServiceName -> Service
-service name =
-  Service
-    { svcName = name
-    , svcConfig = SvcOllama (OllamaConfig Nothing)
-    }
+  , ( "all routed services are rejected when backend cannot list models"
+    , ( ConfigSimple SimpleConfig
+          { simpleTrigger = TriggerAll
+          , simpleService = svcA
+          , simpleProfile = profA
+          }
+      , "_anything"
+      )
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-a", Nothing)
+          ]
+        , testResponses = M.empty
+        }
+    )
 
-
-profA :: ServiceProf
-profA =
-  serviceProf "svc-a" "model-a"
-
-
-profB :: ServiceProf
-profB =
-  serviceProf "svc-b" "model-b"
-
-
-profOverlay :: ServiceProf
-profOverlay =
-  serviceProf "svc-overlay" "model-overlay"
-
-
-serviceProf :: ServiceName -> ModelName -> ServiceProf
-serviceProf serviceName modelName =
-  ServiceProf
-    { profService = serviceName
-    , profModel = modelName
-    , profTemplate = Nothing
-    , profModelOptions = Nothing
-    , profNumExpr = Just 5
-    , profIncludeDocs = Just False
-    }
-
-
-callA :: ServiceCall
-callA =
-  ServiceCall
-    { callProfile = profA
-    , callService = svcA
-    }
-
-
-callB :: ServiceCall
-callB =
-  ServiceCall
-    { callProfile = profB
-    , callService = svcB
-    }
-
-
-callOverlay :: ServiceCall
-callOverlay =
-  ServiceCall
-    { callProfile = profOverlay
-    , callService = svcOverlay
-    }
-
-
-holeName :: Text -> HoleName
-holeName = id
-
-
--- Indexed fixtures for order properties
-----------------------------------------
-
-indexedProfileName :: Int -> ProfileName
-indexedProfileName i =
-  ProfileName ("p" <> T.pack (show i))
-
-
-indexedServiceName :: Int -> ServiceName
-indexedServiceName i =
-  ServiceName ("svc" <> T.pack (show i))
-
-
-indexedModelName :: Int -> ModelName
-indexedModelName i =
-  ModelName ("model" <> T.pack (show i))
-
-
-indexedService :: Int -> Service
-indexedService i =
-  service (indexedServiceName i)
-
-
-indexedServiceProf :: Int -> ServiceProf
-indexedServiceProf i =
-  serviceProf (indexedServiceName i) (indexedModelName i)
-
-
-indexedServiceProfile :: Int -> Profile
-indexedServiceProfile i =
-  serviceProfile
-    (indexedProfileName i)
-    TriggerNone
-    (indexedServiceProf i)
-
-
--- Generators
--------------
-
-genTriggerPolicy :: QC.Gen TriggerPolicy
-genTriggerPolicy =
-  QC.oneof
-    [ pure TriggerNone
-    , pure TriggerAll
-    , TriggerPrefix <$> genPrefixText
-    ]
-
-
-genPrefixText :: QC.Gen Text
-genPrefixText =
-  T.pack <$> QC.listOf1 genIdentChar
-
-
-genHoleName :: QC.Gen HoleName
-genHoleName =
-  QC.oneof
-    [ holeName . ("_" <>) <$> genPrefixText
-    , holeName . ("_" <>) <$> genPrefixTextWithSuffix
-    ]
-
-
-genPrefixTextWithSuffix :: QC.Gen Text
-genPrefixTextWithSuffix = do
-  prefix <- genPrefixText
-  suffix <- T.pack <$> QC.listOf genIdentChar
-  pure (prefix <> suffix)
-
-
-genIdentChar :: QC.Gen Char
-genIdentChar =
-  QC.elements $
-    ['a' .. 'z']
-      <> ['A' .. 'Z']
-      <> ['0' .. '9']
-      <> "_"
-
-
-genDistinctIndices :: QC.Gen [Int]
-genDistinctIndices = do
-  n <- QC.chooseInt (1, 8)
-  xs <- QC.shuffle [1 .. n]
-  pure (nub xs)
+  , ( "all routed services are rejected when model is missing"
+    , ( ConfigSimple SimpleConfig
+          { simpleTrigger = TriggerAll
+          , simpleService = svcA
+          , simpleProfile = profA
+          }
+      , "_anything"
+      )
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-a", Just [ModelName "other-model"])
+          ]
+        , testResponses = M.empty
+        }
+    )
+  ]

--- a/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Spec.hs
@@ -1,0 +1,12 @@
+module GHC.Plugin.OllamaHoles.Data.ServiceCall.Spec (tests) where
+
+import Test.Tasty (TestTree, testGroup)
+
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.Route.Spec qualified as RouteSpec
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.Submit.Spec qualified as SubmitSpec
+
+tests :: TestTree
+tests = testGroup "ServiceCall"
+  [ RouteSpec.tests
+  , SubmitSpec.tests
+  ]

--- a/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit/Spec.hs
@@ -93,12 +93,13 @@ tests_submitRoutedServiceCalls_prop = testGroup "submitRoutedServiceCalls (prop)
               , cfgExtras = Just (ConfigOverride emptyOverrides)
               }
 
-          env =
-            ServiceCallTestEnv
-              { testModels = M.fromList
-                [ ( indexedServiceName i , Just [indexedModelName i] )
-                | i <- indices
-                ]
+          env = ServiceCallTestEnv
+              { testOllamaModels =
+                  Just
+                    [ indexedModelName i
+                    | i <- indices
+                    ]
+              , testOpenAIModels = Nothing
               , testResponses = M.fromList
                 [ ( indexedServiceName i
                   , PromptResponse ("response-" <> T.pack (show i)) )
@@ -126,9 +127,8 @@ tests_submitRoutedServiceCalls_unit_success =
         }
     , "_anything"
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-a", Just [ModelName "model-a"])
-          ]
+        { testOllamaModels = Just [ModelName "model-a"]
+        , testOpenAIModels = Nothing
         , testResponses = M.fromList
           [ (ServiceName "svc-a", PromptResponse "response-a")
           ]
@@ -174,10 +174,11 @@ tests_submitRoutedServiceCalls_unit_success =
         }
     , "_anything"
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-a", Just [ModelName "model-a"])
-          , (ServiceName "svc-b", Just [ModelName "model-b"])
+        { testOllamaModels = Just
+          [ ModelName "model-a"
+          , ModelName "model-b"
           ]
+        , testOpenAIModels = Nothing
         , testResponses = M.fromList
           [ (ServiceName "svc-a", PromptResponse "response-a")
           , (ServiceName "svc-b", PromptResponse "response-b")
@@ -226,16 +227,18 @@ tests_submitRoutedServiceCalls_unit_success =
         }
     , "_anything"
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-a", Just [ModelName "model-a"])
-          , (ServiceName "svc-b", Nothing)
-          ]
+        { testOllamaModels = Just [ModelName "model-a"]
+        , testOpenAIModels = Nothing
         , testResponses = M.fromList
           [ (ServiceName "svc-a", PromptResponse "response-a")
           ]
         }
     , ( [PromptResponse "response-a"]
-      , [SkippedServiceCannotListModels (ServiceName "svc-b")]
+      , [ SkippedServiceMissingModel
+          (ServiceName "svc-b")
+          (ModelName "model-b")
+          [ModelName "model-a"]
+        ]
       )
     )
   ]
@@ -251,9 +254,8 @@ tests_submitRoutedServiceCalls_unit_failure =
         }
     , "_other"
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-a", Just [ModelName "model-a"])
-          ]
+        { testOllamaModels = Just [ModelName "model-a"]
+        , testOpenAIModels = Nothing
         , testResponses = M.empty
         }
     )
@@ -266,9 +268,8 @@ tests_submitRoutedServiceCalls_unit_failure =
         }
     , "_anything"
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-a", Just [ModelName "not-model-a"])
-          ]
+        { testOllamaModels = Just [ModelName "not-model-a"]
+        , testOpenAIModels = Nothing
         , testResponses = M.empty
         }
     )
@@ -281,9 +282,8 @@ tests_submitRoutedServiceCalls_unit_failure =
         }
     , "_anything"
     , ServiceCallTestEnv
-        { testModels = M.fromList
-          [ (ServiceName "svc-a", Just [ModelName "model-a"])
-          ]
+        { testOllamaModels = Just [ModelName "model-a"]
+        , testOpenAIModels = Nothing
         , testResponses = M.empty
         }
     )

--- a/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit/Spec.hs
@@ -1,0 +1,290 @@
+module GHC.Plugin.OllamaHoles.Data.ServiceCall.Submit.Spec
+  ( tests
+  ) where
+
+import Control.Monad.Except
+import Data.Functor ((<&>))
+import Data.Map qualified as M
+import Data.Text qualified as T
+import Data.List.NonEmpty qualified as NE
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck qualified as QC
+
+import GHC.Plugin.OllamaHoles.Data.Config
+import GHC.Plugin.OllamaHoles.Data.Profile
+import GHC.Plugin.OllamaHoles.Data.Service
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.Error
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.Submit
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.TestM
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.Types
+import GHC.Plugin.OllamaHoles.Data.Trigger
+
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.Types.Gen
+
+
+
+tests :: TestTree
+tests = testGroup "GHC.Plugin.OllamaHoles.Data.ServiceCall.Submit"
+  [ tests_submitRoutedServiceCalls_unit
+  , tests_submitRoutedServiceCalls_prop
+  ]
+
+
+
+run_submitRoutedServiceCalls
+  :: Config -> String -> ServiceCallTestEnv
+  -> Either ServiceCallError ([PromptResponse], [ModelSelectionWarning])
+run_submitRoutedServiceCalls config holeName env =
+  case runTestM $ runExceptT $ submitRoutedServiceCalls
+    (serviceCallOps env) "." config (T.pack holeName) unusedPromptContext
+  of
+    Left err -> Left err
+    Right responses -> Right
+      ( serviceCallResponses responses
+      , serviceCallWarnings responses
+      )
+
+tests_submitRoutedServiceCalls_unit :: TestTree
+tests_submitRoutedServiceCalls_unit = testGroup "submitRoutedServiceCalls (unit)"
+  [ testGroup "success" $
+      tests_submitRoutedServiceCalls_unit_success <&>
+        \(name, config, holeName, env, expected) ->
+          testCase name $
+            run_submitRoutedServiceCalls config holeName env @?= Right expected
+
+  , testGroup "failure" $
+      tests_submitRoutedServiceCalls_unit_failure <&>
+        \(name, config, holeName, env) ->
+          testCase name $
+            case run_submitRoutedServiceCalls config holeName env of
+              Left _ -> pure ()
+              Right ok -> assertFailure $
+                "expected failed routed service submission but got: " <> show ok
+  ]
+
+tests_submitRoutedServiceCalls_prop :: TestTree
+tests_submitRoutedServiceCalls_prop = testGroup "submitRoutedServiceCalls (prop)"
+  [ QC.testProperty "fanout response order follows routed service order" $
+      QC.forAll genDistinctIndices $ \indices ->
+        let
+          services = [ indexedService i | i <- indices ]
+          children = [ indexedServiceProfile i | i <- indices ]
+
+          fan = Profile
+            { profName = ProfileName "fan"
+            , profTrigger = TriggerAll
+            , profKind = ProfFanout FanoutProf
+            { profProfiles =
+                NE.fromList
+                    [ indexedProfileName i
+                    | i <- indices
+                    ]
+            }
+            }
+
+          config =
+            ConfigFancy FancyConfig
+              { cfgServices = M.fromList
+                [ (svcName svc, svc) | svc <- services ]
+              , cfgProfiles = M.fromList
+                [ (profName profile, profile) | profile <- fan : children ]
+              , cfgExtras = Just (ConfigOverride emptyOverrides)
+              }
+
+          env =
+            ServiceCallTestEnv
+              { testModels = M.fromList
+                [ ( indexedServiceName i , Just [indexedModelName i] )
+                | i <- indices
+                ]
+              , testResponses = M.fromList
+                [ ( indexedServiceName i
+                  , PromptResponse ("response-" <> T.pack (show i)) )
+                | i <- indices
+                ]
+              }
+
+          expectedResponses =
+            [ PromptResponse ("response-" <> T.pack (show i)) | i <- indices ]
+        in
+          run_submitRoutedServiceCalls config "_anything" env
+            QC.=== Right (expectedResponses, [])
+  ]
+
+
+
+tests_submitRoutedServiceCalls_unit_success
+  :: [(String, Config, String, ServiceCallTestEnv, ([PromptResponse], [ModelSelectionWarning]))]
+tests_submitRoutedServiceCalls_unit_success =
+  [ ( "submits one routed simple service"
+    , ConfigSimple SimpleConfig
+        { simpleTrigger = TriggerAll
+        , simpleService = svcA
+        , simpleProfile = profA
+        }
+    , "_anything"
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-a", Just [ModelName "model-a"])
+          ]
+        , testResponses = M.fromList
+          [ (ServiceName "svc-a", PromptResponse "response-a")
+          ]
+        }
+    , ( [PromptResponse "response-a"]
+      , []
+      )
+    )
+
+  , ( "submits fanout services in routed order"
+    , ConfigFancy FancyConfig
+        { cfgServices = M.fromList
+          [ (ServiceName "svc-a", svcA)
+          , (ServiceName "svc-b", svcB)
+          ]
+        , cfgProfiles = M.fromList
+          [ ( ProfileName "a"
+            , Profile
+                { profName = ProfileName "a"
+                , profTrigger = TriggerNone
+                , profKind = ProfService profA
+                }
+            )
+          , ( ProfileName "b"
+            , Profile
+                { profName = ProfileName "b"
+                , profTrigger = TriggerNone
+                , profKind = ProfService profB
+                }
+            )
+          , ( ProfileName "fan"
+            , Profile
+                { profName = ProfileName "fan"
+                , profTrigger = TriggerAll
+                , profKind = ProfFanout FanoutProf
+                  { profProfiles =
+                      ProfileName "b" NE.:| [ProfileName "a"]
+                  }
+                }
+            )
+          ]
+        , cfgExtras = Just (ConfigOverride emptyOverrides)
+        }
+    , "_anything"
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-a", Just [ModelName "model-a"])
+          , (ServiceName "svc-b", Just [ModelName "model-b"])
+          ]
+        , testResponses = M.fromList
+          [ (ServiceName "svc-a", PromptResponse "response-a")
+          , (ServiceName "svc-b", PromptResponse "response-b")
+          ]
+        }
+    , ( [ PromptResponse "response-b"
+        , PromptResponse "response-a"
+        ]
+      , []
+      )
+    )
+
+  , ( "returns model-selection warnings from skipped routed services"
+    , ConfigFancy FancyConfig
+        { cfgServices = M.fromList
+          [ (ServiceName "svc-a", svcA)
+          , (ServiceName "svc-b", svcB)
+          ]
+        , cfgProfiles = M.fromList
+          [ ( ProfileName "a"
+            , Profile
+                { profName = ProfileName "a"
+                , profTrigger = TriggerNone
+                , profKind = ProfService profA
+                }
+            )
+          , ( ProfileName "b"
+            , Profile
+                { profName = ProfileName "b"
+                , profTrigger = TriggerNone
+                , profKind = ProfService profB
+                }
+            )
+          , ( ProfileName "fan"
+            , Profile
+                { profName = ProfileName "fan"
+                , profTrigger = TriggerAll
+                , profKind = ProfFanout FanoutProf
+                  { profProfiles =
+                      ProfileName "a" NE.:| [ProfileName "b"]
+                  }
+                }
+            )
+          ]
+        , cfgExtras = Just (ConfigOverride emptyOverrides)
+        }
+    , "_anything"
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-a", Just [ModelName "model-a"])
+          , (ServiceName "svc-b", Nothing)
+          ]
+        , testResponses = M.fromList
+          [ (ServiceName "svc-a", PromptResponse "response-a")
+          ]
+        }
+    , ( [PromptResponse "response-a"]
+      , [SkippedServiceCannotListModels (ServiceName "svc-b")]
+      )
+    )
+  ]
+
+tests_submitRoutedServiceCalls_unit_failure
+  :: [(String, Config, String, ServiceCallTestEnv)]
+tests_submitRoutedServiceCalls_unit_failure =
+  [ ( "fails when no service routes"
+    , ConfigSimple SimpleConfig
+        { simpleTrigger = TriggerPrefix "llm"
+        , simpleService = svcA
+        , simpleProfile = profA
+        }
+    , "_other"
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-a", Just [ModelName "model-a"])
+          ]
+        , testResponses = M.empty
+        }
+    )
+
+  , ( "fails when all routed services are filtered before submission"
+    , ConfigSimple SimpleConfig
+        { simpleTrigger = TriggerAll
+        , simpleService = svcA
+        , simpleProfile = profA
+        }
+    , "_anything"
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-a", Just [ModelName "not-model-a"])
+          ]
+        , testResponses = M.empty
+        }
+    )
+
+  , ( "fails when submitter has no fake response for accepted service"
+    , ConfigSimple SimpleConfig
+        { simpleTrigger = TriggerAll
+        , simpleService = svcA
+        , simpleProfile = profA
+        }
+    , "_anything"
+    , ServiceCallTestEnv
+        { testModels = M.fromList
+          [ (ServiceName "svc-a", Just [ModelName "model-a"])
+          ]
+        , testResponses = M.empty
+        }
+    )
+  ]

--- a/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/TestM.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/TestM.hs
@@ -50,11 +50,9 @@ runTestM =
 
 
 data ServiceCallTestEnv = ServiceCallTestEnv
-  { testModels
-      :: M.Map ServiceName (Maybe [ModelName])
-
-  , testResponses
-      :: M.Map ServiceName PromptResponse
+  { testOllamaModels :: Maybe [ModelName]
+  , testOpenAIModels :: Maybe [ModelName]
+  , testResponses :: M.Map ServiceName PromptResponse
   }
 
 
@@ -62,10 +60,9 @@ data ServiceCallTestEnv = ServiceCallTestEnv
 listModelsFromEnv
   :: ServiceCallTestEnv -> Service -> TestM (Maybe [ModelName])
 listModelsFromEnv env service =
-  pure $
-    M.findWithDefault Nothing
-      (svcName service)
-      (testModels env)
+  pure $ case svcConfig service of
+    SvcOllama{} -> testOllamaModels env
+    SvcOpenAI{} -> testOpenAIModels env
 
 
 

--- a/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/TestM.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/TestM.hs
@@ -1,0 +1,216 @@
+module GHC.Plugin.OllamaHoles.Data.ServiceCall.TestM
+  ( TestM
+  , runTestM
+  , ServiceCallTestEnv(..)
+  , serviceCallOps
+  , listModelsFromEnv
+  , unusedPromptContext
+  , svcA
+  , svcB
+  , emptyOverrides
+  , svcOverlay
+  , profA
+  , profB
+  , profOverlay
+
+    -- Indexed fixtures
+  , indexedProfileName
+  , indexedServiceName
+  , indexedModelName
+  , indexedService
+  , indexedServiceProf
+  , indexedServiceProfile
+  , indexedPromptResponse
+  ) where
+
+import Control.Monad.Except
+import Data.Functor.Identity
+import Data.Map qualified as M
+import Data.Text qualified as T
+
+import GHC.Plugin.OllamaHoles.Backend
+import GHC.Plugin.OllamaHoles.Prompt
+import GHC.Plugin.OllamaHoles.Data.Profile
+import GHC.Plugin.OllamaHoles.Data.Service
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.Error
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.Types
+import GHC.Plugin.OllamaHoles.Data.Template
+import GHC.Plugin.OllamaHoles.Data.Config
+import GHC.Plugin.OllamaHoles.Data.Trigger
+
+
+
+type TestM =
+  Identity
+
+runTestM :: TestM a -> a
+runTestM =
+  runIdentity
+
+
+
+data ServiceCallTestEnv = ServiceCallTestEnv
+  { testModels
+      :: M.Map ServiceName (Maybe [ModelName])
+
+  , testResponses
+      :: M.Map ServiceName PromptResponse
+  }
+
+
+
+listModelsFromEnv
+  :: ServiceCallTestEnv -> Service -> TestM (Maybe [ModelName])
+listModelsFromEnv env service =
+  pure $
+    M.findWithDefault Nothing
+      (svcName service)
+      (testModels env)
+
+
+
+serviceCallOps
+  :: ServiceCallTestEnv -> ServiceCallOps TestM
+serviceCallOps env = ServiceCallOps
+  { opsListModels =
+      listModelsFromEnv env
+
+  , opsGetServiceCallTemplate = \_path _call ->
+      pure unusedTemplate
+
+  , opsSubmitServiceCall = \_request call -> do
+      let serviceName =
+            svcName (callService call)
+
+      case M.lookup serviceName (testResponses env) of
+        Just response ->
+          pure response
+
+        Nothing ->
+          throwError $
+            ServiceCallError $
+              "missing fake response for service: "
+                <> show serviceName
+  }
+
+
+
+unusedTemplate :: Template
+unusedTemplate =
+  error "unused test template"
+
+
+
+unusedPromptContext :: PromptContext
+unusedPromptContext =
+  error "unused test prompt context"
+
+
+
+emptyOverrides :: OverrideConfig
+emptyOverrides =
+  OverrideConfig
+    { overrideModelName = Nothing
+    , overrideTemplate = Nothing
+    , overrideModelOptions = Nothing
+    , overrideNumExpr = Nothing
+    , overrideIncludeDocs = Nothing
+    }
+
+svcA :: Service
+svcA =
+  Service
+    { svcName = ServiceName "svc-a"
+    , svcConfig = SvcOllama (OllamaConfig Nothing)
+    }
+
+svcB :: Service
+svcB =
+  Service
+    { svcName = ServiceName "svc-b"
+    , svcConfig = SvcOllama (OllamaConfig Nothing)
+    }
+
+svcOverlay :: Service
+svcOverlay =
+  Service
+    { svcName = ServiceName "svc-overlay"
+    , svcConfig = SvcOllama (OllamaConfig Nothing)
+    }
+
+profA :: ServiceProf
+profA =
+  ServiceProf
+    { profService = ServiceName "svc-a"
+    , profModel = ModelName "model-a"
+    , profTemplate = Nothing
+    , profModelOptions = Nothing
+    , profNumExpr = Just 5
+    , profIncludeDocs = Just False
+    }
+
+profB :: ServiceProf
+profB =
+  ServiceProf
+    { profService = ServiceName "svc-b"
+    , profModel = ModelName "model-b"
+    , profTemplate = Nothing
+    , profModelOptions = Nothing
+    , profNumExpr = Just 5
+    , profIncludeDocs = Just False
+    }
+
+profOverlay :: ServiceProf
+profOverlay =
+  ServiceProf
+    { profService = ServiceName "svc-overlay"
+    , profModel = ModelName "model-overlay"
+    , profTemplate = Nothing
+    , profModelOptions = Nothing
+    , profNumExpr = Just 5
+    , profIncludeDocs = Just False
+    }
+
+
+
+indexedProfileName :: Int -> ProfileName
+indexedProfileName i =
+  ProfileName ("p" <> T.pack (show i))
+
+indexedServiceName :: Int -> ServiceName
+indexedServiceName i =
+  ServiceName ("svc" <> T.pack (show i))
+
+indexedModelName :: Int -> ModelName
+indexedModelName i =
+  ModelName ("model" <> T.pack (show i))
+
+indexedService :: Int -> Service
+indexedService i =
+  Service
+    { svcName = indexedServiceName i
+    , svcConfig = SvcOllama (OllamaConfig Nothing)
+    }
+
+indexedServiceProf :: Int -> ServiceProf
+indexedServiceProf i =
+  ServiceProf
+    { profService = indexedServiceName i
+    , profModel = indexedModelName i
+    , profTemplate = Nothing
+    , profModelOptions = Nothing
+    , profNumExpr = Just 5
+    , profIncludeDocs = Just False
+    }
+
+indexedServiceProfile :: Int -> Profile
+indexedServiceProfile i =
+  Profile
+    { profName = indexedProfileName i
+    , profTrigger = TriggerNone
+    , profKind = ProfService (indexedServiceProf i)
+    }
+
+indexedPromptResponse :: Int -> PromptResponse
+indexedPromptResponse i =
+  PromptResponse ("response-" <> T.pack (show i))

--- a/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Types/Gen.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Types/Gen.hs
@@ -1,0 +1,50 @@
+module GHC.Plugin.OllamaHoles.Data.ServiceCall.Types.Gen where
+
+import Data.List.NonEmpty qualified as NE
+import Data.List (nub)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Test.Tasty.QuickCheck qualified as QC
+
+import GHC.Plugin.OllamaHoles.Data.Trigger
+
+
+
+genTriggerPolicy :: QC.Gen TriggerPolicy
+genTriggerPolicy =
+  QC.oneof
+    [ pure TriggerNone
+    , pure TriggerAll
+    , TriggerPrefix <$> genPrefixText
+    ]
+
+genPrefixText :: QC.Gen Text
+genPrefixText =
+  T.pack <$> QC.listOf1 genIdentChar
+
+genHoleName :: QC.Gen Text
+genHoleName =
+  QC.oneof
+    [ ("_" <>) <$> genPrefixText
+    , ("_" <>) <$> genPrefixTextWithSuffix
+    ]
+
+genPrefixTextWithSuffix :: QC.Gen Text
+genPrefixTextWithSuffix = do
+  prefix <- genPrefixText
+  suffix <- T.pack <$> QC.listOf genIdentChar
+  pure (prefix <> suffix)
+
+genIdentChar :: QC.Gen Char
+genIdentChar =
+  QC.elements $
+    ['a' .. 'z']
+      <> ['A' .. 'Z']
+      <> ['0' .. '9']
+      <> "_"
+
+genDistinctIndices :: QC.Gen [Int]
+genDistinctIndices = do
+  n <- QC.chooseInt (1, 8)
+  xs <- QC.shuffle [1 .. n]
+  pure (nub xs)

--- a/spec/GHC/Plugin/OllamaHoles/Data/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/Spec.hs
@@ -8,6 +8,7 @@ import GHC.Plugin.OllamaHoles.Data.Template.Spec qualified as TemplateSpec
 import GHC.Plugin.OllamaHoles.Data.Service.Spec qualified as ServiceSpec
 import GHC.Plugin.OllamaHoles.Data.Profile.Spec qualified as ProfileSpec
 import GHC.Plugin.OllamaHoles.Data.Prefs.Spec qualified as PrefsSpec
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.Spec qualified as ServiceCallSpec
 
 
 
@@ -19,4 +20,5 @@ tests = testGroup "GHC.Plugin.OllamaHoles.Data"
   , ServiceSpec.tests
   , ProfileSpec.tests
   , PrefsSpec.tests
+  , ServiceCallSpec.tests
   ]

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -7,7 +7,7 @@ import qualified GHC.Plugin.OllamaHoles.Candidate.Rewrite.Spec as RewriteSpec
 import qualified GHC.Plugin.OllamaHoles.Candidate.Compat.Spec as CompatSpec
 import qualified GHC.Plugin.OllamaHoles.Options.Spec as OptionsSpec
 import qualified GHC.Plugin.OllamaHoles.Logger.Spec as LoggerSpec
-import qualified GHC.Plugin.OllamaHoles.Data.ServiceCall.Route.Spec as ServiceCallRouteSpec
+import qualified GHC.Plugin.OllamaHoles.Data.ServiceCall.Spec as ServiceCallSpec
 import qualified GHC.Plugin.OllamaHoles.Data.Config.Build.Spec as BuildSpec
 import qualified GHC.Plugin.OllamaHoles.Data.Spec as DataSpec
 
@@ -20,7 +20,7 @@ main = defaultMain $
         , CompatSpec.tests
         , OptionsSpec.tests
         , LoggerSpec.tests
-        , ServiceCallRouteSpec.tests
+        , ServiceCallSpec.tests
         , BuildSpec.tests
         , DataSpec.tests
         ]

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -7,7 +7,6 @@ import qualified GHC.Plugin.OllamaHoles.Candidate.Rewrite.Spec as RewriteSpec
 import qualified GHC.Plugin.OllamaHoles.Candidate.Compat.Spec as CompatSpec
 import qualified GHC.Plugin.OllamaHoles.Options.Spec as OptionsSpec
 import qualified GHC.Plugin.OllamaHoles.Logger.Spec as LoggerSpec
-import qualified GHC.Plugin.OllamaHoles.Data.ServiceCall.Spec as ServiceCallSpec
 import qualified GHC.Plugin.OllamaHoles.Data.Config.Build.Spec as BuildSpec
 import qualified GHC.Plugin.OllamaHoles.Data.Spec as DataSpec
 
@@ -20,7 +19,6 @@ main = defaultMain $
         , CompatSpec.tests
         , OptionsSpec.tests
         , LoggerSpec.tests
-        , ServiceCallSpec.tests
         , BuildSpec.tests
         , DataSpec.tests
         ]

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -128,7 +128,7 @@ tryPluginInitLLM opts = do
   logger <- liftIO $ Log.initLogger (log_mode flags) (log_dir flags)
   template <- liftEitherIO TemplateParseError $ loadTemplate spec
   config <- modifyError SomeConfigError $ buildConfig flags
-  backendCache <- liftIO $ newBackendCache config
+  backendCache <- liftIO newBackendCache
   let ops = mkServiceCallOps backendCache
   pure $ PluginState
     { candidates     = []
@@ -468,39 +468,33 @@ defaultTemplateSearchDir = "."
 
 
 
-type BackendCache =
-  IORef (M.Map ServiceName Backend)
+newtype BackendCache = BackendCache
+  { unBackendCache :: IORef (M.Map BackendConfig Backend)
+  }
 
-newBackendCache
-  :: Config -> IO BackendCache
-newBackendCache config = newIORef $ M.fromList
-  [ (svcName service, configureBackend (svcConfig service))
-  | service <- configServices config
-  ]
+newBackendCache :: IO BackendCache
+newBackendCache =
+  BackendCache <$> newIORef M.empty
 
-configServices :: Config -> [Service]
-configServices = \case
-  ConfigSimple simple -> [simpleService simple]
-  ConfigFancy fancy ->
-    M.elems (cfgServices fancy) <> extraServices fancy
-
-extraServices :: FancyConfig -> [Service]
-extraServices fancy = case cfgExtras fancy of
-  Just (ConfigOverlay simple) -> [simpleService simple]
-  Just (ConfigOverride _) -> []
-  Nothing -> []
+backendForConfig
+  :: BackendCache -> BackendConfig -> IO Backend
+backendForConfig (BackendCache ref) config = do
+  cache <- readIORef ref
+  case M.lookup config cache of
+    Just backend ->
+      pure backend
+    Nothing -> do
+      let backend =
+            configureBackend config
+      atomicModifyIORef' ref $ \cache0 ->
+        ( M.insert config backend cache0
+        , backend
+        )
 
 backendForService
   :: BackendCache -> Service -> IO Backend
-backendForService ref service = do
-  cache <- readIORef ref
-  case M.lookup (svcName service) cache of
-    Just backend -> pure backend
-    Nothing -> do
-      let backend = configureBackend (svcConfig service)
-      atomicModifyIORef' ref $ \cache0 ->
-        (M.insert (svcName service) backend cache0, ())
-      pure backend
+backendForService cache service =
+  backendForConfig cache (svcConfig service)
 
 mkServiceCallOps
   :: BackendCache -> ServiceCallOps TcM
@@ -514,6 +508,5 @@ mkServiceCallOps backendCache = ServiceCallOps
   , opsSubmitServiceCall = \request call -> do
       backend <- liftIO $
         backendForService backendCache (callService call)
-
       submitServiceCallWithBackend backend request call
   }

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -5,18 +5,16 @@
 -- | The Ollama plugin for GHC
 module GHC.Plugin.OllamaHoles where
 
-import Control.Monad (unless, when, forM_, (>=>), filterM)
+import Control.Monad (unless, when, forM_, (>=>))
 import Control.Monad.Except (ExceptT, runExceptT, MonadError(..), liftEither, modifyError, withExceptT)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.Class (MonadTrans(..))
-import Data.Aeson (Value)
 import Data.Char (isSpace)
 import Data.Foldable (traverse_)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Data.Traversable (for)
-import Data.Map (Map)
 import Data.Map qualified as M
 import Data.List qualified as L
 import GHC.IORef

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -11,11 +11,15 @@ import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.Class (MonadTrans(..))
 import Data.Aeson (Value)
 import Data.Char (isSpace)
+import Data.Foldable (traverse_)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Data.Traversable (for)
+import Data.Map (Map)
+import Data.Map qualified as M
 import Data.List qualified as L
+import GHC.IORef
 import GHC.Plugins hiding ((<>))
 import GHC.Tc.Types
 import GHC.Tc.Types.Constraint (Hole (..))
@@ -96,6 +100,7 @@ data PluginState = PluginState
   , parsedTemplate :: Template
   , commandOptions :: Flags
   , configuration  :: Config
+  , serviceCallOps :: ServiceCallOps TcM
   }
 
 setCandidates :: [HoleFitCandidate] -> PluginState -> PluginState
@@ -125,6 +130,8 @@ tryPluginInitLLM opts = do
   logger <- liftIO $ Log.initLogger (log_mode flags) (log_dir flags)
   template <- liftEitherIO TemplateParseError $ loadTemplate spec
   config <- modifyError SomeConfigError $ buildConfig flags
+  backendCache <- liftIO $ newBackendCache config
+  let ops = mkServiceCallOps backendCache
   pure $ PluginState
     { candidates     = []
     , writeLogEvent  = logger
@@ -132,6 +139,7 @@ tryPluginInitLLM opts = do
     , parsedTemplate = template
     , commandOptions = flags
     , configuration  = config
+    , serviceCallOps = ops
     }
 
 
@@ -168,39 +176,14 @@ tryFitPluginLLM
 tryFitPluginLLM st typedHole fits = do
   debugMsg st $ "running with flags\n" <> T.pack (show $ commandOptions st)
   withTypedHole typedHole $ \hole -> do
-    -- Find the services which match on this hole
     let holeName = holeTriggerName hole
-    services' <- case routeServiceCalls (configuration st) holeName of
-      Left err -> throwError $ RouteConfigPluginError err
-      Right Nothing -> pure []
-      Right (Just matches) -> pure matches
-    debugMsg st $ "Hole " <> holeName <> " matched " <> T.pack (show $ length services') <> " service(s)"
-
-    -- Filter for and warn about invalid model names
-    -- TODO: move this check to ServiceCall.Submit; need to distinguish between failure modes.
-    --   * backend cannot list models
-    --   * model not found for some service
-    --   * no routed services remain after filtering
-    services <- flip filterM services' $ \svc -> do
-      available_models <- liftIO $ listModels $ configureBackend $ svcConfig $ callService svc
-      case available_models of
-        Nothing -> pure False
-        Just models -> if unModelName (profModel (callProfile svc)) `elem` models
-          then pure True
-          else do
-            -- TODO: warn here
-            pure False
-
-    when (null services) $ throwError NoModelsAvailable
-
+    let templateSearchPath = maybe "." id $ template_search_dir $ commandOptions st
     ctx <- buildPromptContext st typedHole fits
-    let path = maybe "." id $ template_search_dir $ commandOptions st
-
-    -- Query each service with the prompt context
-    responses <- withExceptT ServiceCallPluginError $ for services $ \svc -> do
-      template <- getServiceCallTemplate path svc
-      submitServiceCall (PromptRequest ctx template) svc
-
+    ServiceCallResponses responses warnings <- withExceptT ServiceCallPluginError $
+      submitRoutedServiceCalls (serviceCallOps st) templateSearchPath
+      (configuration st) holeName ctx
+    -- log service warnings
+    traverse_ (warnMsg st . renderModelSelectionWarning) warnings
     lift $ extractHoleFitsFromPromptResponses st responses typedHole hole
 
 
@@ -225,12 +208,6 @@ buildPromptContext st hole fits = do
   case getPromptContext hole fits gblEnv (candidates st) dflags of
     Just ctx -> pure ctx
     Nothing -> throwError (TypedHoleNotFound hole)
-
-
-
-effectiveModelOptions :: PluginState -> ServiceProf -> Maybe Value
-effectiveModelOptions st serviceProf =
-  profModelOptions serviceProf
 
 
 
@@ -447,6 +424,10 @@ debugMsg :: (MonadIO m) => PluginState -> Text -> m ()
 debugMsg st txt = liftIO $ when (maybe True id $ debug $ commandOptions st) $
   T.putStrLn $ pluginName <> ": " <> txt
 
+warnMsg :: (MonadIO m) => PluginState -> Text -> m ()
+warnMsg st txt = liftIO $ when (maybe True id $ debug $ commandOptions st) $
+  T.putStrLn $ pluginName <> ": " <> txt
+
 liftEitherIO :: (MonadIO m) => (e1 -> e2) -> IO (Either e1 a) -> ExceptT e2 m a
 liftEitherIO f act = liftIO act >>= either (throwError . f) pure
 
@@ -486,3 +467,55 @@ defaultOpenAIKeyName = "OPENAI_API_KEY"
 
 defaultTemplateSearchDir :: Text
 defaultTemplateSearchDir = "."
+
+
+
+type BackendCache =
+  IORef (M.Map ServiceName Backend)
+
+newBackendCache
+  :: Config -> IO BackendCache
+newBackendCache config = newIORef $ M.fromList
+  [ (svcName service, configureBackend (svcConfig service))
+  | service <- configServices config
+  ]
+
+configServices :: Config -> [Service]
+configServices = \case
+  ConfigSimple simple -> [simpleService simple]
+  ConfigFancy fancy ->
+    M.elems (cfgServices fancy) <> extraServices fancy
+
+extraServices :: FancyConfig -> [Service]
+extraServices fancy = case cfgExtras fancy of
+  Just (ConfigOverlay simple) -> [simpleService simple]
+  Just (ConfigOverride _) -> []
+  Nothing -> []
+
+backendForService
+  :: BackendCache -> Service -> IO Backend
+backendForService ref service = do
+  cache <- readIORef ref
+  case M.lookup (svcName service) cache of
+    Just backend -> pure backend
+    Nothing -> do
+      let backend = configureBackend (svcConfig service)
+      atomicModifyIORef' ref $ \cache0 ->
+        (M.insert (svcName service) backend cache0, ())
+      pure backend
+
+mkServiceCallOps
+  :: BackendCache -> ServiceCallOps TcM
+mkServiceCallOps backendCache = ServiceCallOps
+  { opsListModels = \service -> liftIO $ do
+      backend <- backendForService backendCache service
+      fmap (map ModelName) <$> listModels backend
+
+  , opsGetServiceCallTemplate = getServiceCallTemplate
+
+  , opsSubmitServiceCall = \request call -> do
+      backend <- liftIO $
+        backendForService backendCache (callService call)
+
+      submitServiceCallWithBackend backend request call
+  }

--- a/src/GHC/Plugin/OllamaHoles/Backend.hs
+++ b/src/GHC/Plugin/OllamaHoles/Backend.hs
@@ -43,7 +43,7 @@ data BackendConfig
   = SvcOllama OllamaConfig
   | SvcOpenAI OpenAIConfig
   | SvcGemini GeminiConfig
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 configureBackend :: BackendConfig -> Backend
 configureBackend = \case

--- a/src/GHC/Plugin/OllamaHoles/Backend/Gemini.hs
+++ b/src/GHC/Plugin/OllamaHoles/Backend/Gemini.hs
@@ -22,7 +22,7 @@ import Data.Maybe
 
 data GeminiConfig = GeminiConfig
   { svcGeminiKeyName :: Text
-  } deriving (Eq, Show, Generic)
+  } deriving (Eq, Ord, Show, Generic)
 
 
 

--- a/src/GHC/Plugin/OllamaHoles/Backend/Ollama.hs
+++ b/src/GHC/Plugin/OllamaHoles/Backend/Ollama.hs
@@ -18,7 +18,7 @@ import GHC.Plugin.OllamaHoles.Backend.Common
 
 data OllamaConfig = OllamaConfig
   { svcOllamaHost :: Maybe Text
-  } deriving (Eq, Show, Generic)
+  } deriving (Eq, Ord, Show, Generic)
 
 
 

--- a/src/GHC/Plugin/OllamaHoles/Backend/OpenAI.hs
+++ b/src/GHC/Plugin/OllamaHoles/Backend/OpenAI.hs
@@ -27,7 +27,7 @@ import Text.URI (mkURI)
 data OpenAIConfig = OpenAIConfig
   { svcOpenAIBaseUrl :: Text
   , svcOpenAIKeyName :: Text
-  } deriving (Eq, Show, Generic)
+  } deriving (Eq, Ord, Show, Generic)
 
 -- | The OpenAI backend
 openAIBackend :: Backend

--- a/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Error.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Error.hs
@@ -34,6 +34,8 @@ renderRouteConfigError = \case
 
 data ServiceCallError
   = ServiceCallError String
+  | ServiceCallModelError ModelSelectionError
+  | ServiceCallRouteError RouteConfigError
   | ServiceCallTemplateError TemplateError
   deriving (Eq, Show)
 
@@ -42,5 +44,62 @@ renderServiceCallError = \case
   ServiceCallError msg ->
     "service call error: " <> T.pack msg
 
+  ServiceCallModelError err ->
+    "service call model error: " <> renderModelSelectionError err
+
+  ServiceCallRouteError err ->
+    renderRouteConfigError err
+
   ServiceCallTemplateError templateError ->
     "failed to load template: " <> T.pack (show templateError)
+
+
+
+data ModelSelectionError
+  = NoServiceCallsRouted Text -- hole name
+  | CannotListModels ServiceName
+  | ModelNameNotFound ServiceName ModelName [ModelName]
+  | NoServiceCallsAfterModelFiltering [ModelSelectionWarning]
+  deriving (Eq, Show)
+
+renderModelSelectionError :: ModelSelectionError -> Text
+renderModelSelectionError = \case
+  NoServiceCallsRouted holeName ->
+    "no services routed for hole: " <> holeName
+
+  CannotListModels serviceName ->
+    "could not list models for service: " <> unServiceName serviceName
+
+  ModelNameNotFound serviceName modelName models ->
+    "model "
+      <> unModelName modelName
+      <> " not found for service "
+      <> unServiceName serviceName
+      <> "; available models: "
+      <> T.intercalate ", " (map unModelName models)
+
+  NoServiceCallsAfterModelFiltering warnings ->
+    "no routed services remain after model filtering: "
+      <> T.intercalate "; " (map renderModelSelectionWarning warnings)
+
+
+
+data ModelSelectionWarning
+  = SkippedServiceCannotListModels ServiceName
+  | SkippedServiceMissingModel ServiceName ModelName [ModelName]
+  deriving (Eq, Show)
+
+renderModelSelectionWarning :: ModelSelectionWarning -> Text
+renderModelSelectionWarning = \case
+  SkippedServiceCannotListModels serviceName ->
+    "skipped "
+      <> unServiceName serviceName
+      <> " because the backend could not list models"
+
+  SkippedServiceMissingModel serviceName modelName models ->
+    "skipped "
+      <> unServiceName serviceName
+      <> " because model "
+      <> unModelName modelName
+      <> " was not found; available models: "
+      <> T.intercalate ", " (map unModelName models)

--- a/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Route.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Route.hs
@@ -1,18 +1,76 @@
 module GHC.Plugin.OllamaHoles.Data.ServiceCall.Route
-  ( routeServiceCalls
+  ( prepareServiceCalls
   ) where
 
 import Control.Applicative
+import Control.Monad (when)
+import Control.Monad.Except (ExceptT(..), throwError)
+import Control.Monad.Trans (MonadTrans(..))
 import Data.List (sortOn)
 import Data.Map qualified as M
 import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Traversable (for)
 
+import GHC.Plugin.OllamaHoles.Data.Service
 import GHC.Plugin.OllamaHoles.Data.Profile
 import GHC.Plugin.OllamaHoles.Data.Trigger
 import GHC.Plugin.OllamaHoles.Data.Config
 
 import GHC.Plugin.OllamaHoles.Data.ServiceCall.Types
 import GHC.Plugin.OllamaHoles.Data.ServiceCall.Error
+
+
+
+-- | Given a @Config@ object and a hole name, route
+-- to the matching @ServiceCall@s and filter out any
+-- for which the model name is invalid.
+prepareServiceCalls
+  :: (Monad m)
+  => (Service -> m (Maybe [ModelName]))
+  -> Config -> Text {- HoleName -}
+  -> ExceptT ServiceCallError m CheckedServiceCalls
+prepareServiceCalls listServiceModels config holeName = do
+  routed <- case routeServiceCalls config holeName of
+    Left err -> throwError (ServiceCallRouteError err)
+    Right Nothing -> throwError $
+      ServiceCallModelError $ NoServiceCallsRouted holeName
+    Right (Just calls) -> pure calls
+
+  calls@(CheckedServiceCalls accepted warnings) <- lift $
+    filterServiceCallsByAvailableModels listServiceModels routed
+
+  when (null accepted) $ throwError $
+    ServiceCallModelError $ NoServiceCallsAfterModelFiltering warnings
+
+  pure calls
+
+filterServiceCallsByAvailableModels
+  :: Monad m
+  => (Service -> m (Maybe [ModelName]))
+  -> [ServiceCall]
+  -> m CheckedServiceCalls
+filterServiceCallsByAvailableModels listServiceModels calls = do
+  results <- for calls $ \call -> do
+    let
+      service = callService call
+      serviceName = svcName service
+      wantedModel = profModel (callProfile call)
+
+    mModels <- listServiceModels service
+    case mModels of
+      Nothing -> pure $ Left $
+        SkippedServiceCannotListModels serviceName
+      Just models
+        | wantedModel `elem` models -> pure (Right call)
+        | otherwise -> pure $ Left $
+            SkippedServiceMissingModel serviceName wantedModel models
+
+  pure CheckedServiceCalls
+    { checkedAccepted = [ call | Right call <- results ]
+    , checkedWarnings = [ warning | Left warning <- results ]
+    }
+
 
 
 

--- a/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Route.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Route.hs
@@ -109,7 +109,7 @@ routeFancyOverlay fancy holeName = case cfgExtras fancy of
   Just (ConfigOverride _) -> Nothing
   -- If there is an overlay, route it like a simple config.
   Just (ConfigOverlay overlay) -> routeSimpleConfig overlay holeName
-  _ -> error "routeFancyOverlay"
+  Nothing -> Nothing
 
 routeFancyProfiles
   :: FancyConfig -> HoleName
@@ -148,7 +148,7 @@ serviceCallForServiceProf fancy prof =
 
 applyExtraConfig :: FancyConfig -> ServiceProf -> ServiceProf
 applyExtraConfig fancy serviceProf = case cfgExtras fancy of
-  Nothing -> error "applyExtraConfig"
+  Nothing -> serviceProf
   Just (ConfigOverlay _) -> serviceProf
   Just (ConfigOverride overrides) -> applyOverrideConfig overrides serviceProf
 

--- a/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit.hs
@@ -5,6 +5,7 @@ module GHC.Plugin.OllamaHoles.Data.ServiceCall.Submit
 
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Except
+import Data.Maybe (fromMaybe)
 import Data.Traversable (for)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -48,7 +49,8 @@ renderPromptForServiceCall req caller = do
 --    if effectiveIncludeDocs (callProfile caller)
 --      then getDocs (candidates st)
 --      else pure ""
-  let effectiveNumExpr = const 10
+  let effectiveNumExpr profile =
+        fromMaybe 10 (profNumExpr profile)
 
   let result = expandTemplate template $ mkTemplateEnv
         [ ("backend", unServiceName (svcName (callService caller)))

--- a/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit.hs
@@ -1,34 +1,39 @@
 module GHC.Plugin.OllamaHoles.Data.ServiceCall.Submit
-  ( submitServiceCall
+  ( submitRoutedServiceCalls
+  , submitServiceCallWithBackend
   ) where
 
-import Data.Text (Text)
-import Data.Text qualified as T
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Except
+import Data.Traversable (for)
+import Data.Text (Text)
+import Data.Text qualified as T
 import GHC.Tc.Types (TcM)
 
 import GHC.Plugin.OllamaHoles.Prompt
 import GHC.Plugin.OllamaHoles.Backend
+import GHC.Plugin.OllamaHoles.Data.Config
 import GHC.Plugin.OllamaHoles.Data.Template
 import GHC.Plugin.OllamaHoles.Data.Profile
 import GHC.Plugin.OllamaHoles.Data.Service
 import GHC.Plugin.OllamaHoles.Data.ServiceCall.Types
 import GHC.Plugin.OllamaHoles.Data.ServiceCall.Error
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.Template
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.Route
 
 
 
-submitServiceCall
-  :: PromptRequest -> ServiceCall
+submitServiceCallWithBackend
+  :: Backend -> PromptRequest -> ServiceCall
   -> ExceptT ServiceCallError TcM PromptResponse
-submitServiceCall req caller = do
+submitServiceCallWithBackend backend req caller = do
   prompt <- renderPromptForServiceCall req caller
   let
-    backend = configureBackend $ svcConfig $ callService caller
     serviceProf = callProfile caller
     model = unModelName $ profModel serviceProf
     options = profModelOptions serviceProf
   result <- liftIO $ generateFits backend prompt model options
+
   case result of
     Left err -> throwError $ ServiceCallError err
     Right response -> pure $ PromptResponse response
@@ -55,3 +60,18 @@ renderPromptForServiceCall req caller = do
   case result of
     Left err -> throwError $ ServiceCallTemplateError err
     Right ok -> pure ok
+
+
+
+submitRoutedServiceCalls
+  :: (Monad m)
+  => ServiceCallOps m -> FilePath -> Config
+  -> Text {- HoleName -} -> PromptContext
+  -> ExceptT ServiceCallError m ServiceCallResponses
+submitRoutedServiceCalls ops templateSearchDir config holeName ctx = do
+  CheckedServiceCalls calls warnings <- prepareServiceCalls
+    (opsListModels ops) config holeName
+  responses <- for calls $ \call -> do
+    template <- opsGetServiceCallTemplate ops templateSearchDir call
+    opsSubmitServiceCall ops (PromptRequest ctx template) call
+  pure $ ServiceCallResponses responses warnings

--- a/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Types.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Types.hs
@@ -1,11 +1,14 @@
 module GHC.Plugin.OllamaHoles.Data.ServiceCall.Types where
 
+import Control.Monad.Except (ExceptT)
 import Data.Text (Text)
 
 import GHC.Plugin.OllamaHoles.Prompt
+import GHC.Plugin.OllamaHoles.Data.Config
 import GHC.Plugin.OllamaHoles.Data.Template
 import GHC.Plugin.OllamaHoles.Data.Service
 import GHC.Plugin.OllamaHoles.Data.Profile
+import GHC.Plugin.OllamaHoles.Data.ServiceCall.Error
 
 
 
@@ -22,3 +25,28 @@ data PromptRequest = PromptRequest
 data PromptResponse = PromptResponse
   { unPromptResponse :: Text
   } deriving (Eq, Show)
+
+-- | Type modeling service calls where the service was
+-- able to list the available models and the specified
+-- model shown to exist. Warnings correspond to services
+-- where either of those conditions does not hold.
+data CheckedServiceCalls = CheckedServiceCalls
+  { checkedAccepted :: [ServiceCall]
+  , checkedWarnings :: [ModelSelectionWarning]
+  } deriving (Eq, Show)
+
+data ServiceCallResponses = ServiceCallResponses
+  { serviceCallResponses :: [PromptResponse]
+  , serviceCallWarnings  :: [ModelSelectionWarning]
+  }
+
+data ServiceCallOps m = ServiceCallOps
+  { opsListModels
+      :: Service -> m (Maybe [ModelName])
+  , opsSubmitServiceCall
+      :: PromptRequest -> ServiceCall
+      -> ExceptT ServiceCallError m PromptResponse
+  , opsGetServiceCallTemplate
+      :: FilePath -> ServiceCall
+      -> ExceptT ServiceCallError m Template
+  }

--- a/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Types.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Types.hs
@@ -38,7 +38,7 @@ data CheckedServiceCalls = CheckedServiceCalls
 data ServiceCallResponses = ServiceCallResponses
   { serviceCallResponses :: [PromptResponse]
   , serviceCallWarnings  :: [ModelSelectionWarning]
-  }
+  } deriving (Eq, Show)
 
 data ServiceCallOps m = ServiceCallOps
   { opsListModels


### PR DESCRIPTION
`ServiceCall` is an abstraction representing a call to a backend and its response. This patch refactors `ServiceCall` so that routing holes and submitting to the backend can be pulled into the library and tested independently.