### PR TITLE
Do not use Flags after init

### DIFF
--- a/spec/GHC/Plugin/OllamaHoles/Data/Config/Build/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/Config/Build/Spec.hs
@@ -116,7 +116,7 @@ test_buildConfig_prop = testGroup "buildConfig (prop)"
           })
         Nothing
 
-      pure $ case result of
+      pure $ case fmap configMode result of
         Right ConfigSimple{} -> QC.property True
         other -> QC.counterexample
           ("expected ConfigSimple, got: " <> show other)
@@ -130,7 +130,7 @@ test_buildConfig_prop = testGroup "buildConfig (prop)"
           })
         (Just ("config.toml", basicFancyToml))
 
-      pure $ case result of
+      pure $ case fmap configMode result of
         Right ConfigSimple{} -> QC.property True
         other -> QC.counterexample
           ("expected ConfigSimple, got: " <> show other)
@@ -164,7 +164,7 @@ test_buildConfig_prop = testGroup "buildConfig (prop)"
                 })
               (Just ("config.toml", toml))
 
-            pure $ case result of
+            pure $ case fmap configMode result of
               Left err -> QC.counterexample
                 ("unexpected error: " <> show err <> "\n\nTOML:\n" <> T.unpack toml)
                 False
@@ -223,7 +223,7 @@ tests_buildConfig_unit_basic_success =
         { config_path = Just ConfigDisabled
         }
     , Nothing
-    , ConfigSimple $ SimpleConfig
+    , defaultConfigOfMode $ ConfigSimple $ SimpleConfig
         { simpleTrigger = defaultTriggerPolicy
         , simpleService = Service
           { svcName = ServiceName "__simple__"
@@ -254,7 +254,7 @@ tests_buildConfig_unit_basic_success =
         , template_path = Just "prompt.txt"
         }
     , Nothing
-    , ConfigSimple SimpleConfig
+    , defaultConfigOfMode $ ConfigSimple SimpleConfig
         { simpleTrigger = TriggerAll
         , simpleService = Service
           { svcName = ServiceName "__simple__"
@@ -287,7 +287,7 @@ tests_buildConfig_unit_basic_success =
         \  { name = 'p', type = 'service', trigger = 'prefix:llm', service = 'ollama', model = 'qwen3:latest' }\n\
         \]"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "ollama"
             , Service
@@ -336,7 +336,7 @@ tests_buildConfig_unit_basic_success =
         \  { name = 'p', type = 'service', trigger = 'prefix:llm', service = 'ollama', model = 'qwen3:latest' }\n\
         \]"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "ollama"
             , Service
@@ -392,7 +392,7 @@ tests_buildConfig_unit_basic_success =
         \  { name = 'p', type = 'service', trigger = 'prefix:llm', service = 'ollama', model = 'qwen3:latest' }\n\
         \]"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "ollama"
             , Service
@@ -452,7 +452,7 @@ tests_buildConfig_unit_basic_success =
         { config_path = Just ConfigDisabled
         }
     , Just ("config.toml", basicFancyToml)
-    , ConfigSimple SimpleConfig
+    , defaultConfigOfMode $ ConfigSimple SimpleConfig
         { simpleTrigger = defaultTriggerPolicy
         , simpleService = Service
           { svcName = ServiceName "__simple__"
@@ -474,7 +474,7 @@ tests_buildConfig_unit_basic_success =
         { config_path = Nothing
         }
     , Nothing
-    , ConfigSimple SimpleConfig
+    , defaultConfigOfMode $ ConfigSimple SimpleConfig
         { simpleTrigger = defaultTriggerPolicy
         , simpleService = Service
           { svcName = ServiceName "__simple__"
@@ -508,7 +508,7 @@ tests_buildConfig_unit_basic_success =
         \  { name = 'p', type = 'service', trigger = 'prefix:llm', service = 'ollama', model = 'qwen3:latest' }\n\
         \]"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "ollama"
             , Service
@@ -544,7 +544,7 @@ tests_buildConfig_unit_basic_success =
         , template_name = Just $ unsafeCreateRawTemplateName "compact"
         }
     , Nothing
-    , ConfigSimple SimpleConfig
+    , defaultConfigOfMode $ ConfigSimple SimpleConfig
         { simpleTrigger = defaultTriggerPolicy
         , simpleService = Service
           { svcName = ServiceName "__simple__"
@@ -567,7 +567,7 @@ tests_buildConfig_unit_basic_success =
         , template_name = Just $ unsafeCreateRawTemplateName "compact"
         }
     , Nothing
-    , ConfigSimple SimpleConfig
+    , defaultConfigOfMode $ ConfigSimple SimpleConfig
         { simpleTrigger = defaultTriggerPolicy
         , simpleService = Service
           { svcName = ServiceName "__simple__"
@@ -600,7 +600,7 @@ tests_buildConfig_unit_basic_success =
         \  { name = 'p', type = 'service', trigger = 'prefix:llm', service = 'ollama', model = 'qwen3:latest' }\n\
         \]"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "ollama"
             , Service
@@ -652,7 +652,7 @@ tests_buildConfig_unit_basic_success =
         \  { name = 'p', type = 'service', trigger = 'prefix:llm', service = 'ollama', model = 'qwen3:latest' }\n\
         \]"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "ollama"
             , Service
@@ -708,7 +708,7 @@ tests_buildConfig_unit_basic_success =
         \  { name = 'p', type = 'service', trigger = 'prefix:llm', service = 'ollama', model = 'qwen3:latest' }\n\
         \]"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "ollama"
             , Service
@@ -781,7 +781,7 @@ tests_buildConfig_unit_basic_success =
         \  { name = 'p', type = 'service', trigger = 'prefix:llm', service = 'ollama', model = 'qwen3:latest' }\n\
         \]"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "ollama"
             , Service
@@ -852,7 +852,7 @@ tests_buildConfig_unit_basic_success =
         \  { name = 'p', type = 'service', trigger = 'prefix:llm', service = 'ollama', model = 'qwen3:latest' }\n\
         \]"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "ollama"
             , Service
@@ -923,7 +923,7 @@ tests_buildConfig_unit_basic_success =
         \  { name = 'p', type = 'service', trigger = 'prefix:llm', service = 'ollama', model = 'qwen3:latest' }\n\
         \]"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "ollama"
             , Service
@@ -987,7 +987,7 @@ tests_buildConfig_unit_basic_success =
       , "services = []\n\
         \profiles = []"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList []
         , cfgProfiles = M.fromList []
         , cfgExtras = Just
@@ -999,6 +999,58 @@ tests_buildConfig_unit_basic_success =
                 , overrideTemplate = Nothing
                 }
             )
+        }
+    )
+
+  , ( "debug flag false becomes configDebug false"
+    , \_path -> mempty
+        { debug = Just False
+        , config_path = Just ConfigDisabled
+        }
+    , Nothing
+    , Config
+        { configDebug = False
+        , configMode = ConfigSimple SimpleConfig
+          { simpleTrigger = defaultTriggerPolicy
+          , simpleService = Service
+            { svcName = ServiceName "__simple__"
+            , svcConfig = SvcOllama (OllamaConfig Nothing)
+            }
+          , simpleProfile = ServiceProf
+            { profService = ServiceName "__simple__"
+            , profModel = ModelName "qwen3:latest"
+            , profTemplate = Nothing
+            , profModelOptions = Nothing
+            , profNumExpr = Just 5
+            , profIncludeDocs = Just False
+            }
+          }
+        }
+    )
+
+  , ( "debug flag true becomes configDebug true"
+    , \_path -> mempty
+        { debug = Just True
+        , config_path = Just ConfigDisabled
+        }
+    , Nothing
+    , Config
+        { configDebug = True
+        , configMode = ConfigSimple SimpleConfig
+          { simpleTrigger = defaultTriggerPolicy
+          , simpleService = Service
+            { svcName = ServiceName "__simple__"
+            , svcConfig = SvcOllama (OllamaConfig Nothing)
+            }
+          , simpleProfile = ServiceProf
+            { profService = ServiceName "__simple__"
+            , profModel = ModelName "qwen3:latest"
+            , profTemplate = Nothing
+            , profModelOptions = Nothing
+            , profNumExpr = Just 5
+            , profIncludeDocs = Just False
+            }
+          }
         }
     )
   ]
@@ -1112,7 +1164,7 @@ tests_buildConfig_unit_validate_success =
       ( "config.toml"
       , nestedFanoutToml
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "ollama"
             , Service
@@ -1184,7 +1236,7 @@ tests_buildConfig_unit_validate_success =
         \\n\
         \profiles = []"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "ollama"
             , Service
@@ -1220,7 +1272,7 @@ tests_buildConfig_unit_validate_success =
         \  { name = 'p', type = 'service', service = 'ollama', model = 'qwen3:latest' }\n\
         \]"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "ollama"
             , Service
@@ -1266,7 +1318,7 @@ tests_buildConfig_unit_validate_success =
         \  { name = 'outer', type = 'fanout', profiles = ['inner', 'leaf1'] }\n\
         \]"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "local"
             , Service
@@ -1345,7 +1397,7 @@ tests_buildConfig_unit_validate_success =
         \  { name = 'rich', type = 'service', trigger = 'all', service = 'remote', model = 'gpt-test', template = 'prompt', num_expr = 17, include_docs = true }\n\
         \]"
       )
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ ( ServiceName "remote"
             , Service

--- a/spec/GHC/Plugin/OllamaHoles/Data/Config/Build/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/Config/Build/Spec.hs
@@ -1010,6 +1010,7 @@ tests_buildConfig_unit_basic_success =
     , Nothing
     , Config
         { configDebug = False
+        , configTemplateSearchDir = "."
         , configMode = ConfigSimple SimpleConfig
           { simpleTrigger = defaultTriggerPolicy
           , simpleService = Service
@@ -1036,6 +1037,60 @@ tests_buildConfig_unit_basic_success =
     , Nothing
     , Config
         { configDebug = True
+        , configTemplateSearchDir = "."
+        , configMode = ConfigSimple SimpleConfig
+          { simpleTrigger = defaultTriggerPolicy
+          , simpleService = Service
+            { svcName = ServiceName "__simple__"
+            , svcConfig = SvcOllama (OllamaConfig Nothing)
+            }
+          , simpleProfile = ServiceProf
+            { profService = ServiceName "__simple__"
+            , profModel = ModelName "qwen3:latest"
+            , profTemplate = Nothing
+            , profModelOptions = Nothing
+            , profNumExpr = Just 5
+            , profIncludeDocs = Just False
+            }
+          }
+        }
+    )
+
+  , ( "missing template search dir flag defaults to current directory"
+    , \_path -> mempty
+        { config_path = Just ConfigDisabled
+        }
+    , Nothing
+    , Config
+        { configDebug = False
+        , configTemplateSearchDir = "."
+        , configMode = ConfigSimple SimpleConfig
+          { simpleTrigger = defaultTriggerPolicy
+          , simpleService = Service
+            { svcName = ServiceName "__simple__"
+            , svcConfig = SvcOllama (OllamaConfig Nothing)
+            }
+          , simpleProfile = ServiceProf
+            { profService = ServiceName "__simple__"
+            , profModel = ModelName "qwen3:latest"
+            , profTemplate = Nothing
+            , profModelOptions = Nothing
+            , profNumExpr = Just 5
+            , profIncludeDocs = Just False
+            }
+          }
+        }
+    )
+
+  , ( "template search dir flag becomes configTemplateSearchDir"
+    , \_path -> mempty
+        { config_path = Just ConfigDisabled
+        , template_search_dir = Just "templates"
+        }
+    , Nothing
+    , Config
+        { configDebug = False
+        , configTemplateSearchDir = "templates"
         , configMode = ConfigSimple SimpleConfig
           { simpleTrigger = defaultTriggerPolicy
           , simpleService = Service

--- a/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Route/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Route/Spec.hs
@@ -72,13 +72,13 @@ tests_prepareServiceCalls_prop = testGroup "prepareServiceCalls (prop)"
       QC.forAll genTriggerPolicy $ \trigger ->
       QC.forAll genHoleName $ \hn ->
         let
-          config = ConfigSimple SimpleConfig
+          config = defaultConfigOfMode $ ConfigSimple SimpleConfig
             { simpleTrigger = trigger
             , simpleService = svcA
             , simpleProfile = profA
             }
 
-          env =  ServiceCallTestEnv
+          env = ServiceCallTestEnv
             { testOllamaModels = Just [ModelName "model-a"]
             , testOpenAIModels = Nothing
             , testResponses = M.empty
@@ -115,7 +115,7 @@ tests_prepareServiceCalls_prop = testGroup "prepareServiceCalls (prop)"
               }
             }
 
-          config = ConfigFancy FancyConfig
+          config = defaultConfigOfMode $ ConfigFancy FancyConfig
             { cfgServices = M.fromList
               [ (svcName svc, svc) | svc <- services ]
             , cfgProfiles = M.fromList
@@ -151,7 +151,7 @@ tests_prepareServiceCalls_unit_success
   :: [(String, (Config, Text), ServiceCallTestEnv, CheckedServiceCalls)]
 tests_prepareServiceCalls_unit_success =
   [ ( "simple config returns one service call when trigger matches"
-    , ( ConfigSimple SimpleConfig
+    , ( defaultConfigOfMode $ ConfigSimple SimpleConfig
           { simpleTrigger = TriggerPrefix "llm"
           , simpleService = svcA
           , simpleProfile = profA
@@ -175,7 +175,7 @@ tests_prepareServiceCalls_unit_success =
     )
 
   , ( "TriggerAll in simple config always routes"
-    , ( ConfigSimple SimpleConfig
+    , ( defaultConfigOfMode $ ConfigSimple SimpleConfig
           { simpleTrigger = TriggerAll
           , simpleService = svcA
           , simpleProfile = profA
@@ -199,7 +199,7 @@ tests_prepareServiceCalls_unit_success =
     )
 
   , ( "fancy overlay takes priority over matching config profile"
-    , ( ConfigFancy FancyConfig
+    , ( defaultConfigOfMode $ ConfigFancy FancyConfig
           { cfgServices = M.fromList
             [ (ServiceName "svc-a", svcA)
             ]
@@ -238,7 +238,7 @@ tests_prepareServiceCalls_unit_success =
     )
 
   , ( "fanout expands child profiles in fanout order"
-    , ( ConfigFancy FancyConfig
+    , ( defaultConfigOfMode $ ConfigFancy FancyConfig
           { cfgServices = M.fromList
             [ (ServiceName "svc-a", svcA)
             , (ServiceName "svc-b", svcB)
@@ -297,7 +297,7 @@ tests_prepareServiceCalls_unit_success =
     )
 
   , ( "one missing model is warned while other routed services remain"
-    , ( ConfigFancy FancyConfig
+    , ( defaultConfigOfMode $ ConfigFancy FancyConfig
           { cfgServices = M.fromList
             [ (ServiceName "svc-a", svcA)
             , (ServiceName "svc-b", svcB)
@@ -354,7 +354,7 @@ tests_prepareServiceCalls_unit_success =
   )
 
   , ( "normal route uses configured service when overlay has same service name"
-    , ( ConfigFancy FancyConfig
+    , ( defaultConfigOfMode $ ConfigFancy FancyConfig
           { cfgServices = M.fromList
             [ ( ServiceName "shared"
               , Service
@@ -431,7 +431,7 @@ tests_prepareServiceCalls_unit_failure
   :: [(String, (Config, Text), ServiceCallTestEnv)]
 tests_prepareServiceCalls_unit_failure =
   [ ( "simple config returns error when trigger does not match"
-    , ( ConfigSimple SimpleConfig
+    , ( defaultConfigOfMode $ ConfigSimple SimpleConfig
           { simpleTrigger = TriggerPrefix "llm"
           , simpleService = svcA
           , simpleProfile = profA
@@ -446,7 +446,7 @@ tests_prepareServiceCalls_unit_failure =
     )
 
   , ( "TriggerNone in simple config never routes"
-    , ( ConfigSimple SimpleConfig
+    , ( defaultConfigOfMode $ ConfigSimple SimpleConfig
           { simpleTrigger = TriggerNone
           , simpleService = svcA
           , simpleProfile = profA
@@ -461,7 +461,7 @@ tests_prepareServiceCalls_unit_failure =
     )
 
   , ( "fancy config reports ambiguous matching profiles"
-    , ( ConfigFancy FancyConfig
+    , ( defaultConfigOfMode $ ConfigFancy FancyConfig
           { cfgServices = M.fromList
             [ (ServiceName "svc-a", svcA)
             , (ServiceName "svc-b", svcB)
@@ -494,7 +494,7 @@ tests_prepareServiceCalls_unit_failure =
     )
 
   , ( "fancy config reports unknown service"
-    , ( ConfigFancy FancyConfig
+    , ( defaultConfigOfMode $ ConfigFancy FancyConfig
           { cfgServices = M.fromList []
           , cfgProfiles = M.fromList
             [ ( ProfileName "p"
@@ -519,7 +519,7 @@ tests_prepareServiceCalls_unit_failure =
     )
 
   , ( "fanout reports unknown child profile"
-    , ( ConfigFancy FancyConfig
+    , ( defaultConfigOfMode $ ConfigFancy FancyConfig
           { cfgServices = M.fromList []
           , cfgProfiles = M.fromList
             [ ( ProfileName "fan"
@@ -545,7 +545,7 @@ tests_prepareServiceCalls_unit_failure =
     )
 
   , ( "all routed services are rejected when backend cannot list models"
-    , ( ConfigSimple SimpleConfig
+    , ( defaultConfigOfMode $ ConfigSimple SimpleConfig
           { simpleTrigger = TriggerAll
           , simpleService = svcA
           , simpleProfile = profA
@@ -560,7 +560,7 @@ tests_prepareServiceCalls_unit_failure =
     )
 
   , ( "all routed services are rejected when model is missing"
-    , ( ConfigSimple SimpleConfig
+    , ( defaultConfigOfMode $ ConfigSimple SimpleConfig
           { simpleTrigger = TriggerAll
           , simpleService = svcA
           , simpleProfile = profA

--- a/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit/Spec.hs
@@ -84,7 +84,7 @@ tests_submitRoutedServiceCalls_prop = testGroup "submitRoutedServiceCalls (prop)
             }
             }
 
-          config =
+          config = defaultConfigOfMode $
             ConfigFancy FancyConfig
               { cfgServices = M.fromList
                 [ (svcName svc, svc) | svc <- services ]
@@ -120,7 +120,7 @@ tests_submitRoutedServiceCalls_unit_success
   :: [(String, Config, String, ServiceCallTestEnv, ([PromptResponse], [ModelSelectionWarning]))]
 tests_submitRoutedServiceCalls_unit_success =
   [ ( "submits one routed simple service"
-    , ConfigSimple SimpleConfig
+    , defaultConfigOfMode $ ConfigSimple SimpleConfig
         { simpleTrigger = TriggerAll
         , simpleService = svcA
         , simpleProfile = profA
@@ -139,7 +139,7 @@ tests_submitRoutedServiceCalls_unit_success =
     )
 
   , ( "submits fanout services in routed order"
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ (ServiceName "svc-a", svcA)
           , (ServiceName "svc-b", svcB)
@@ -192,7 +192,7 @@ tests_submitRoutedServiceCalls_unit_success =
     )
 
   , ( "returns model-selection warnings from skipped routed services"
-    , ConfigFancy FancyConfig
+    , defaultConfigOfMode $ ConfigFancy FancyConfig
         { cfgServices = M.fromList
           [ (ServiceName "svc-a", svcA)
           , (ServiceName "svc-b", svcB)
@@ -247,7 +247,7 @@ tests_submitRoutedServiceCalls_unit_failure
   :: [(String, Config, String, ServiceCallTestEnv)]
 tests_submitRoutedServiceCalls_unit_failure =
   [ ( "fails when no service routes"
-    , ConfigSimple SimpleConfig
+    , defaultConfigOfMode $ ConfigSimple SimpleConfig
         { simpleTrigger = TriggerPrefix "llm"
         , simpleService = svcA
         , simpleProfile = profA
@@ -261,7 +261,7 @@ tests_submitRoutedServiceCalls_unit_failure =
     )
 
   , ( "fails when all routed services are filtered before submission"
-    , ConfigSimple SimpleConfig
+    , defaultConfigOfMode $ ConfigSimple SimpleConfig
         { simpleTrigger = TriggerAll
         , simpleService = svcA
         , simpleProfile = profA
@@ -275,7 +275,7 @@ tests_submitRoutedServiceCalls_unit_failure =
     )
 
   , ( "fails when submitter has no fake response for accepted service"
-    , ConfigSimple SimpleConfig
+    , defaultConfigOfMode $ ConfigSimple SimpleConfig
         { simpleTrigger = TriggerAll
         , simpleService = svcA
         , simpleProfile = profA

--- a/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit/Spec.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit/Spec.hs
@@ -38,7 +38,7 @@ run_submitRoutedServiceCalls
   -> Either ServiceCallError ([PromptResponse], [ModelSelectionWarning])
 run_submitRoutedServiceCalls config holeName env =
   case runTestM $ runExceptT $ submitRoutedServiceCalls
-    (serviceCallOps env) "." config (T.pack holeName) unusedPromptContext
+    (serviceCallOps env) config (T.pack holeName) unusedPromptContext
   of
     Left err -> Left err
     Right responses -> Right
@@ -105,6 +105,7 @@ tests_submitRoutedServiceCalls_prop = testGroup "submitRoutedServiceCalls (prop)
                   , PromptResponse ("response-" <> T.pack (show i)) )
                 | i <- indices
                 ]
+              , testExpectedTemplateSearchDir = Nothing
               }
 
           expectedResponses =
@@ -132,6 +133,7 @@ tests_submitRoutedServiceCalls_unit_success =
         , testResponses = M.fromList
           [ (ServiceName "svc-a", PromptResponse "response-a")
           ]
+        , testExpectedTemplateSearchDir = Nothing
         }
     , ( [PromptResponse "response-a"]
       , []
@@ -183,6 +185,7 @@ tests_submitRoutedServiceCalls_unit_success =
           [ (ServiceName "svc-a", PromptResponse "response-a")
           , (ServiceName "svc-b", PromptResponse "response-b")
           ]
+        , testExpectedTemplateSearchDir = Nothing
         }
     , ( [ PromptResponse "response-b"
         , PromptResponse "response-a"
@@ -232,6 +235,7 @@ tests_submitRoutedServiceCalls_unit_success =
         , testResponses = M.fromList
           [ (ServiceName "svc-a", PromptResponse "response-a")
           ]
+        , testExpectedTemplateSearchDir = Nothing
         }
     , ( [PromptResponse "response-a"]
       , [ SkippedServiceMissingModel
@@ -239,6 +243,30 @@ tests_submitRoutedServiceCalls_unit_success =
           (ModelName "model-b")
           [ModelName "model-a"]
         ]
+      )
+    )
+
+  , ( "uses config template search dir when loading service-call template"
+    , Config
+        { configDebug = False
+        , configTemplateSearchDir = "custom-templates"
+        , configMode = ConfigSimple SimpleConfig
+          { simpleTrigger = TriggerAll
+          , simpleService = svcA
+          , simpleProfile = profA
+          }
+        }
+    , "_anything"
+    , ServiceCallTestEnv
+        { testOllamaModels = Just [ModelName "model-a"]
+        , testOpenAIModels = Nothing
+        , testResponses = M.fromList
+          [ (ServiceName "svc-a", PromptResponse "response-a")
+          ]
+        , testExpectedTemplateSearchDir = Just "custom-templates"
+        }
+    , ( [PromptResponse "response-a"]
+      , []
       )
     )
   ]
@@ -257,6 +285,7 @@ tests_submitRoutedServiceCalls_unit_failure =
         { testOllamaModels = Just [ModelName "model-a"]
         , testOpenAIModels = Nothing
         , testResponses = M.empty
+        , testExpectedTemplateSearchDir = Nothing
         }
     )
 
@@ -271,6 +300,7 @@ tests_submitRoutedServiceCalls_unit_failure =
         { testOllamaModels = Just [ModelName "not-model-a"]
         , testOpenAIModels = Nothing
         , testResponses = M.empty
+        , testExpectedTemplateSearchDir = Nothing
         }
     )
 
@@ -285,6 +315,7 @@ tests_submitRoutedServiceCalls_unit_failure =
         { testOllamaModels = Just [ModelName "model-a"]
         , testOpenAIModels = Nothing
         , testResponses = M.empty
+        , testExpectedTemplateSearchDir = Nothing
         }
     )
   ]

--- a/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/TestM.hs
+++ b/spec/GHC/Plugin/OllamaHoles/Data/ServiceCall/TestM.hs
@@ -53,6 +53,7 @@ data ServiceCallTestEnv = ServiceCallTestEnv
   { testOllamaModels :: Maybe [ModelName]
   , testOpenAIModels :: Maybe [ModelName]
   , testResponses :: M.Map ServiceName PromptResponse
+  , testExpectedTemplateSearchDir :: Maybe FilePath
   }
 
 
@@ -72,8 +73,15 @@ serviceCallOps env = ServiceCallOps
   { opsListModels =
       listModelsFromEnv env
 
-  , opsGetServiceCallTemplate = \_path _call ->
-      pure unusedTemplate
+  , opsGetServiceCallTemplate = \templateSearchDir _call ->
+    case testExpectedTemplateSearchDir env of
+      Nothing -> pure unusedTemplate
+      Just expected
+        | templateSearchDir == expected -> pure unusedTemplate
+        | otherwise -> throwError $
+            ServiceCallTemplateError $ TemplateLoadError $
+              "expected template search dir " <> expected
+                <> ", got " <> templateSearchDir
 
   , opsSubmitServiceCall = \_request call -> do
       let serviceName =

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -96,7 +96,6 @@ data PluginState = PluginState
   , writeLogEvent  :: Log.Logger
   , templateSpec   :: TemplateSpec
   , parsedTemplate :: Template
-  , commandOptions :: Flags
   , configuration  :: Config
   , serviceCallOps :: ServiceCallOps TcM
   }
@@ -138,7 +137,6 @@ tryPluginInitLLM opts = do
         , writeLogEvent  = logger
         , templateSpec   = spec
         , parsedTemplate = template
-        , commandOptions = flags
         , configuration  = config
         , serviceCallOps = ops
         }

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -179,11 +179,9 @@ tryFitPluginLLM
 tryFitPluginLLM st typedHole fits = do
   withTypedHole typedHole $ \hole -> do
     let holeName = holeTriggerName hole
-    let templateSearchPath = maybe "." id $ template_search_dir $ commandOptions st
     ctx <- buildPromptContext st typedHole fits
     ServiceCallResponses responses warnings <- withExceptT ServiceCallPluginError $
-      submitRoutedServiceCalls (serviceCallOps st) templateSearchPath
-      (configuration st) holeName ctx
+      submitRoutedServiceCalls (serviceCallOps st) (configuration st) holeName ctx
     -- log service warnings
     traverse_ (warnMsg st . renderModelSelectionWarning) warnings
     lift $ extractHoleFitsFromPromptResponses st responses typedHole hole

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -104,6 +104,9 @@ data PluginState = PluginState
 setCandidates :: [HoleFitCandidate] -> PluginState -> PluginState
 setCandidates cs st = st { candidates = cs }
 
+isDebugMode :: PluginState -> Bool
+isDebugMode = configDebug . configuration
+
 
 
 -- Initialize
@@ -130,15 +133,17 @@ tryPluginInitLLM opts = do
   config <- modifyError SomeConfigError $ buildConfig flags
   backendCache <- liftIO newBackendCache
   let ops = mkServiceCallOps backendCache
-  pure $ PluginState
-    { candidates     = []
-    , writeLogEvent  = logger
-    , templateSpec   = spec
-    , parsedTemplate = template
-    , commandOptions = flags
-    , configuration  = config
-    , serviceCallOps = ops
-    }
+  let st = PluginState
+        { candidates     = []
+        , writeLogEvent  = logger
+        , templateSpec   = spec
+        , parsedTemplate = template
+        , commandOptions = flags
+        , configuration  = config
+        , serviceCallOps = ops
+        }
+  debugMsg st $ "running with flags: " <> T.pack (show flags)
+  pure st
 
 
 
@@ -172,7 +177,6 @@ tryFitPluginLLM
   :: PluginState -> TypedHole -> [HoleFit]
   -> ExceptT PluginError TcM [HoleFit]
 tryFitPluginLLM st typedHole fits = do
-  debugMsg st $ "running with flags\n" <> T.pack (show $ commandOptions st)
   withTypedHole typedHole $ \hole -> do
     let holeName = holeTriggerName hole
     let templateSearchPath = maybe "." id $ template_search_dir $ commandOptions st
@@ -223,7 +227,7 @@ extractHoleFitsFromResponse
   -> TypedHole -> Hole -> TcM [HoleFit]
 extractHoleFitsFromResponse st prompt rsp hole h = do
   let logger = writeLogEvent st
-  let debugMode = maybe True id $ debug (commandOptions st)
+  let debugMode = isDebugMode st
   dflags <- getDynFlags
 
   -- Get the raw list of candidates
@@ -419,11 +423,11 @@ getDocs cs = do
 --------
 
 debugMsg :: (MonadIO m) => PluginState -> Text -> m ()
-debugMsg st txt = liftIO $ when (maybe True id $ debug $ commandOptions st) $
+debugMsg st txt = liftIO $ when (isDebugMode st) $
   T.putStrLn $ pluginName <> ": " <> txt
 
 warnMsg :: (MonadIO m) => PluginState -> Text -> m ()
-warnMsg st txt = liftIO $ when (maybe True id $ debug $ commandOptions st) $
+warnMsg st txt = liftIO $ when (isDebugMode st) $
   T.putStrLn $ pluginName <> ": " <> txt
 
 liftEitherIO :: (MonadIO m) => (e1 -> e2) -> IO (Either e1 a) -> ExceptT e2 m a

--- a/src/GHC/Plugin/OllamaHoles/Data/Config/Build.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Config/Build.hs
@@ -39,9 +39,11 @@ buildConfig
   :: (MonadIO m) => Flags -> ExceptT ConfigError m Config
 buildConfig flags = do
   intent <- inferConfigKindIntent flags
-  case intent of
+  configMode <- case intent of
     SimpleConfigIntent -> fmap ConfigSimple $ buildSimpleConfig flags
     FancyConfigIntent path raw -> fmap ConfigFancy $ buildFancyConfig path flags raw
+  let configDebug = maybe False id $ debug flags
+  pure $ Config {configMode, configDebug}
 
 
 

--- a/src/GHC/Plugin/OllamaHoles/Data/Config/Build.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Config/Build.hs
@@ -43,7 +43,8 @@ buildConfig flags = do
     SimpleConfigIntent -> fmap ConfigSimple $ buildSimpleConfig flags
     FancyConfigIntent path raw -> fmap ConfigFancy $ buildFancyConfig path flags raw
   let configDebug = maybe False id $ debug flags
-  pure $ Config {configMode, configDebug}
+  let configTemplateSearchDir = maybe "." id $ template_search_dir flags
+  pure $ Config {configMode, configDebug, configTemplateSearchDir}
 
 
 

--- a/src/GHC/Plugin/OllamaHoles/Data/Config/Build.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Config/Build.hs
@@ -1,7 +1,5 @@
 module GHC.Plugin.OllamaHoles.Data.Config.Build
   ( buildConfig
-  , buildServiceMap
-  , buildProfileMap
   ) where
 
 import Control.Exception (try)

--- a/src/GHC/Plugin/OllamaHoles/Data/Config/Types.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Config/Types.hs
@@ -13,8 +13,9 @@ import GHC.Plugin.OllamaHoles.Data.Profile
 
 
 data Config = Config
-  { configMode  :: ConfigMode
-  , configDebug :: Bool
+  { configMode              :: ConfigMode
+  , configDebug             :: Bool
+  , configTemplateSearchDir :: FilePath
   } deriving (Eq, Show, Generic)
 
 data ConfigMode
@@ -53,6 +54,7 @@ data OverrideConfig = OverrideConfig
 defaultConfigOfMode
   :: ConfigMode -> Config
 defaultConfigOfMode mode = Config
-  { configMode  = mode
-  , configDebug = False
+  { configMode              = mode
+  , configDebug             = False
+  , configTemplateSearchDir = "."
   }

--- a/src/GHC/Plugin/OllamaHoles/Data/Config/Types.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Config/Types.hs
@@ -12,7 +12,12 @@ import GHC.Plugin.OllamaHoles.Data.Profile
 
 
 
-data Config
+data Config = Config
+  { configMode  :: ConfigMode
+  , configDebug :: Bool
+  } deriving (Eq, Show, Generic)
+
+data ConfigMode
   = ConfigSimple SimpleConfig
   | ConfigFancy FancyConfig
   deriving (Eq, Show, Generic)
@@ -42,3 +47,12 @@ data OverrideConfig = OverrideConfig
   , overrideModelOptions  :: Maybe Value
   , overrideTemplate      :: Maybe TemplateSource
   } deriving (Eq, Show, Generic)
+
+
+
+defaultConfigOfMode
+  :: ConfigMode -> Config
+defaultConfigOfMode mode = Config
+  { configMode  = mode
+  , configDebug = False
+  }

--- a/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Route.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Route.hs
@@ -79,7 +79,7 @@ filterServiceCallsByAvailableModels listServiceModels calls = do
 routeServiceCalls
   :: Config -> HoleName
   -> Either RouteConfigError (Maybe [ServiceCall])
-routeServiceCalls config holeName = case config of
+routeServiceCalls config holeName = case configMode config of
   ConfigSimple simple -> Right $ routeSimpleConfig simple holeName
   ConfigFancy  fancy  -> routeFancyConfig fancy holeName
 

--- a/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit.hs
@@ -67,10 +67,11 @@ renderPromptForServiceCall req caller = do
 
 submitRoutedServiceCalls
   :: (Monad m)
-  => ServiceCallOps m -> FilePath -> Config
+  => ServiceCallOps m -> Config
   -> Text {- HoleName -} -> PromptContext
   -> ExceptT ServiceCallError m ServiceCallResponses
-submitRoutedServiceCalls ops templateSearchDir config holeName ctx = do
+submitRoutedServiceCalls ops config holeName ctx = do
+  let templateSearchDir = configTemplateSearchDir config
   CheckedServiceCalls calls warnings <- prepareServiceCalls
     (opsListModels ops) config holeName
   responses <- for calls $ \call -> do

--- a/src/GHC/Plugin/OllamaHoles/Data/Template/Error.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/Template/Error.hs
@@ -12,6 +12,7 @@ data TemplateError
     | UnknownPlaceholders [Placeholder]
     | MalformedTemplate Line Col TemplateParseError
     | InvalidTemplateName Text
+    | TemplateLoadError FilePath
     deriving (Eq, Show)
 
 data TemplateParseError


### PR DESCRIPTION
Right now there are two distinct entities whose purposes need to be pulled apart: Flags and Config. Flags represents what is (or is not) included in the command line arguments. Config is for all the runtime read-only state. Upon initialization, the Flags object is parsed out of the raw command line flags, and this is used to construct Config (which is not completely trivial, because it involves things like possibly reading files and choosing defaults).

Because Config is derived from Flags, in principle there is runtime data that could be derived from either one. This is a source of truth bug waiting to blow up, and since we carry both the Flags and the Config in the plugin state it is not hypothetical. The best solution is to remove Flags from plugin state.

There are only two blockers to this: we are still pulling the debug flag and the template search path out of Flags. The plan is roughly this:

1. Put the debug flag and template search path in Config. This will require renaming the current Config (I've chosen ConfigMode) and introducing a new Config type that carries the mode, debug flag, and template search path.
2. Update any code or tests that are broken by the previous step (turns out it's not that much because API surfaces are pretty well separated)
3. Pull the debug flag and template search path out of config when needed
4. Remove Flags from the plugin state.