### PR TITLE
Refactor PluginState

### DIFF
--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -129,6 +129,7 @@ library
       GHC.Plugin.OllamaHoles.Candidate.Compat
       GHC.Plugin.OllamaHoles.Candidate.Rewrite
       GHC.Plugin.OllamaHoles.Constants
+      GHC.Plugin.OllamaHoles.Console
       GHC.Plugin.OllamaHoles.Data.Flags
       GHC.Plugin.OllamaHoles.Data.Flags.Error
       GHC.Plugin.OllamaHoles.Data.Flags.Parse
@@ -191,6 +192,7 @@ library ollama-holes-lib
     , GHC.Plugin.OllamaHoles.Candidate.Compat
     , GHC.Plugin.OllamaHoles.Candidate.Rewrite
     , GHC.Plugin.OllamaHoles.Constants
+    , GHC.Plugin.OllamaHoles.Console
     , GHC.Plugin.OllamaHoles.Data.Flags
     , GHC.Plugin.OllamaHoles.Data.Flags.Error
     , GHC.Plugin.OllamaHoles.Data.Flags.Parse

--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -175,6 +175,7 @@ library
       GHC.Plugin.OllamaHoles.Prompt
       GHC.Plugin.OllamaHoles.Runtime
       GHC.Plugin.OllamaHoles.Runtime.Ops
+      GHC.Plugin.OllamaHoles.Runtime.Init
 
 
 
@@ -238,6 +239,7 @@ library ollama-holes-lib
     , GHC.Plugin.OllamaHoles.Prompt
     , GHC.Plugin.OllamaHoles.Runtime
     , GHC.Plugin.OllamaHoles.Runtime.Ops
+    , GHC.Plugin.OllamaHoles.Runtime.Init
 
 
 

--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -165,6 +165,8 @@ library
       GHC.Plugin.OllamaHoles.Data.Trigger.Error
       GHC.Plugin.OllamaHoles.Data.Trigger.Parse
       GHC.Plugin.OllamaHoles.Data.Trigger.Match
+      GHC.Plugin.OllamaHoles.Data.PluginState
+      GHC.Plugin.OllamaHoles.Data.PluginState.Types
       GHC.Plugin.OllamaHoles.Error
       GHC.Plugin.OllamaHoles.Flags
       GHC.Plugin.OllamaHoles.Logger
@@ -222,6 +224,8 @@ library ollama-holes-lib
     , GHC.Plugin.OllamaHoles.Data.Trigger.Error
     , GHC.Plugin.OllamaHoles.Data.Trigger.Parse
     , GHC.Plugin.OllamaHoles.Data.Trigger.Match
+    , GHC.Plugin.OllamaHoles.Data.PluginState
+    , GHC.Plugin.OllamaHoles.Data.PluginState.Types
     , GHC.Plugin.OllamaHoles.Error
     , GHC.Plugin.OllamaHoles.Flags
     , GHC.Plugin.OllamaHoles.Logger

--- a/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin.cabal
@@ -128,6 +128,7 @@ library
       GHC.Plugin.OllamaHoles.Candidate
       GHC.Plugin.OllamaHoles.Candidate.Compat
       GHC.Plugin.OllamaHoles.Candidate.Rewrite
+      GHC.Plugin.OllamaHoles.Constants
       GHC.Plugin.OllamaHoles.Data.Flags
       GHC.Plugin.OllamaHoles.Data.Flags.Error
       GHC.Plugin.OllamaHoles.Data.Flags.Parse
@@ -171,6 +172,8 @@ library
       GHC.Plugin.OllamaHoles.Flags
       GHC.Plugin.OllamaHoles.Logger
       GHC.Plugin.OllamaHoles.Prompt
+      GHC.Plugin.OllamaHoles.Runtime
+      GHC.Plugin.OllamaHoles.Runtime.Ops
 
 
 
@@ -187,6 +190,7 @@ library ollama-holes-lib
     , GHC.Plugin.OllamaHoles.Candidate
     , GHC.Plugin.OllamaHoles.Candidate.Compat
     , GHC.Plugin.OllamaHoles.Candidate.Rewrite
+    , GHC.Plugin.OllamaHoles.Constants
     , GHC.Plugin.OllamaHoles.Data.Flags
     , GHC.Plugin.OllamaHoles.Data.Flags.Error
     , GHC.Plugin.OllamaHoles.Data.Flags.Parse
@@ -230,6 +234,8 @@ library ollama-holes-lib
     , GHC.Plugin.OllamaHoles.Flags
     , GHC.Plugin.OllamaHoles.Logger
     , GHC.Plugin.OllamaHoles.Prompt
+    , GHC.Plugin.OllamaHoles.Runtime
+    , GHC.Plugin.OllamaHoles.Runtime.Ops
 
 
 

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -15,9 +15,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Data.Traversable (for)
-import Data.Map qualified as M
 import Data.List qualified as L
-import GHC.IORef
 import GHC.Plugins hiding ((<>))
 import GHC.Tc.Types
 import GHC.Tc.Types.Constraint (Hole (..))
@@ -56,10 +54,10 @@ import GHC.Plugin.OllamaHoles.Logger qualified as Log
 import GHC.Plugin.OllamaHoles.Candidate
 import GHC.Plugin.OllamaHoles.Error
 import GHC.Plugin.OllamaHoles.Data.Config
-import GHC.Plugin.OllamaHoles.Data.Service.Types
-import GHC.Plugin.OllamaHoles.Data.Profile.Types
 import GHC.Plugin.OllamaHoles.Data.ServiceCall
 import GHC.Plugin.OllamaHoles.Data.PluginState
+import GHC.Plugin.OllamaHoles.Runtime
+import GHC.Plugin.OllamaHoles.Constants
 
 
 
@@ -91,12 +89,12 @@ hfPluginInitLLM
   :: [CommandLineOption]
   -> TcM (TcRef (Either PluginError (PluginState TcM)))
 hfPluginInitLLM =
-  (liftIO . runExceptT . tryPluginInitLLM)
+  (runExceptT . tryPluginInitLLM)
     >=> printRenderedError >=> newTcRef
 
 -- | Initialize the plugin state
 tryPluginInitLLM
-  :: [CommandLineOption] -> ExceptT PluginError IO (PluginState TcM)
+  :: [CommandLineOption] -> ExceptT PluginError TcM (PluginState TcM)
 tryPluginInitLLM opts = do
   flags <- case parseFlags opts of
     Right (fs, []) -> pure fs
@@ -104,8 +102,7 @@ tryPluginInitLLM opts = do
     Left err       -> throwError $ OptionParseError err
   logger <- liftIO $ Log.initLogger (log_mode flags) (log_dir flags)
   config <- modifyError SomeConfigError $ buildConfig flags
-  backendCache <- liftIO newBackendCache
-  let ops = mkServiceCallOps backendCache
+  ops <- lift newServiceCallOps
   let st = PluginState
         { candidates     = []
         , writeLogEvent  = logger
@@ -400,77 +397,3 @@ printRenderedError x = case x of
   Left err -> do
     liftIO $ T.putStrLn $ renderPluginError err
     pure (Left err)
-
-
-
-defaultModelName :: Text
-defaultModelName = "qwen3:latest"
-
-defaultBackendName :: BackendSlug
-defaultBackendName = Ollama
-
-defaultNumExpr :: Int
-defaultNumExpr = 5
-
-defaultDebug :: Bool
-defaultDebug = True
-
-defaultIncludeDocs :: Bool
-defaultIncludeDocs = True
-
-defaultConfigPath :: ConfigPathSpec
-defaultConfigPath = ConfigDefault
-
-defaultOpenAIBaseUrl :: Text
-defaultOpenAIBaseUrl = "https://api.openai.com"
-
-defaultOpenAIKeyName :: Text
-defaultOpenAIKeyName = "OPENAI_API_KEY"
-
-defaultTemplateSearchDir :: Text
-defaultTemplateSearchDir = "."
-
-
-
-newtype BackendCache = BackendCache
-  { unBackendCache :: IORef (M.Map BackendConfig Backend)
-  }
-
-newBackendCache :: IO BackendCache
-newBackendCache =
-  BackendCache <$> newIORef M.empty
-
-backendForConfig
-  :: BackendCache -> BackendConfig -> IO Backend
-backendForConfig (BackendCache ref) config = do
-  cache <- readIORef ref
-  case M.lookup config cache of
-    Just backend ->
-      pure backend
-    Nothing -> do
-      let backend =
-            configureBackend config
-      atomicModifyIORef' ref $ \cache0 ->
-        ( M.insert config backend cache0
-        , backend
-        )
-
-backendForService
-  :: BackendCache -> Service -> IO Backend
-backendForService cache service =
-  backendForConfig cache (svcConfig service)
-
-mkServiceCallOps
-  :: BackendCache -> ServiceCallOps TcM
-mkServiceCallOps backendCache = ServiceCallOps
-  { opsListModels = \service -> liftIO $ do
-      backend <- backendForService backendCache service
-      fmap (map ModelName) <$> listModels backend
-
-  , opsGetServiceCallTemplate = getServiceCallTemplate
-
-  , opsSubmitServiceCall = \request call -> do
-      backend <- liftIO $
-        backendForService backendCache (callService call)
-      submitServiceCallWithBackend backend request call
-  }

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -5,8 +5,8 @@
 -- | The Ollama plugin for GHC
 module GHC.Plugin.OllamaHoles where
 
-import Control.Monad (unless, when, forM_, (>=>))
-import Control.Monad.Except (ExceptT, runExceptT, MonadError(..), liftEither, modifyError, withExceptT)
+import Control.Monad (unless, when, forM_)
+import Control.Monad.Except (ExceptT, runExceptT, MonadError(..), liftEither, withExceptT)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.Class (MonadTrans(..))
 import Data.Char (isSpace)
@@ -69,23 +69,13 @@ mkHoleFitPluginR
   :: [CommandLineOption] -> HoleFitPluginR
 mkHoleFitPluginR opts = HoleFitPluginR
   -- Initialize the plugin (this may fail).
-  { hfPluginInit = hfPluginInitLLM opts
+  { hfPluginInit = pluginInit opts >>= newTcRef
   , hfPluginStop = \_ -> return ()
   , hfPluginRun = \ref -> HoleFitPlugin
     { candPlugin = \_ cs -> updTcRef ref (fmap (setCandidates cs)) >> return cs
     , fitPlugin = fitPluginLLM ref
     }
   }
-
-
-
--- Initialize
--------------
-
-hfPluginInitLLM
-  :: [CommandLineOption]
-  -> TcM (TcRef (Either PluginError (PluginState TcM)))
-hfPluginInitLLM = pluginInit >=> newTcRef
 
 
 

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -55,12 +55,11 @@ import GHC.Plugin.OllamaHoles.Prompt
 import GHC.Plugin.OllamaHoles.Logger qualified as Log
 import GHC.Plugin.OllamaHoles.Candidate
 import GHC.Plugin.OllamaHoles.Error
-import GHC.Plugin.OllamaHoles.Flags
 import GHC.Plugin.OllamaHoles.Data.Config
 import GHC.Plugin.OllamaHoles.Data.Service.Types
 import GHC.Plugin.OllamaHoles.Data.Profile.Types
 import GHC.Plugin.OllamaHoles.Data.ServiceCall
-import GHC.Plugin.OllamaHoles.Data.Template
+import GHC.Plugin.OllamaHoles.Data.PluginState
 
 
 
@@ -70,15 +69,12 @@ plugin = defaultPlugin
   { holeFitPlugin = Just . mkHoleFitPluginR
   }
 
-pluginName :: Text
-pluginName = "Ollama Plugin"
-
 mkHoleFitPluginR
   :: [CommandLineOption] -> HoleFitPluginR
 mkHoleFitPluginR opts = HoleFitPluginR
   { hfPluginInit =
       -- Initialize the plugin (this may fail).
-      hfPluginInitLLM opts :: TcM (TcRef (Either PluginError PluginState))
+      hfPluginInitLLM opts :: TcM (TcRef (Either PluginError (PluginState TcM)))
   , hfPluginStop = \_ -> return ()
   , hfPluginRun = \ref -> HoleFitPlugin
     { candPlugin = \_ cs -> updTcRef ref (fmap (setCandidates cs)) >> return cs
@@ -88,44 +84,24 @@ mkHoleFitPluginR opts = HoleFitPluginR
 
 
 
--- State
---------
-
-data PluginState = PluginState
-  { candidates     :: [HoleFitCandidate]
-  , writeLogEvent  :: Log.Logger
-  , templateSpec   :: TemplateSpec
-  , configuration  :: Config
-  , serviceCallOps :: ServiceCallOps TcM
-  }
-
-setCandidates :: [HoleFitCandidate] -> PluginState -> PluginState
-setCandidates cs st = st { candidates = cs }
-
-isDebugMode :: PluginState -> Bool
-isDebugMode = configDebug . configuration
-
-
-
 -- Initialize
 -------------
 
 hfPluginInitLLM
   :: [CommandLineOption]
-  -> TcM (TcRef (Either PluginError PluginState))
+  -> TcM (TcRef (Either PluginError (PluginState TcM)))
 hfPluginInitLLM =
   (liftIO . runExceptT . tryPluginInitLLM)
     >=> printRenderedError >=> newTcRef
 
 -- | Initialize the plugin state
 tryPluginInitLLM
-  :: [CommandLineOption] -> ExceptT PluginError IO PluginState
+  :: [CommandLineOption] -> ExceptT PluginError IO (PluginState TcM)
 tryPluginInitLLM opts = do
   flags <- case parseFlags opts of
     Right (fs, []) -> pure fs
     Right (_, unk) -> throwError $ UnknownOptionError unk
     Left err       -> throwError $ OptionParseError err
-  spec <- liftEitherIO TemplateSpecError $ pure $ mkTemplateSpec flags
   logger <- liftIO $ Log.initLogger (log_mode flags) (log_dir flags)
   config <- modifyError SomeConfigError $ buildConfig flags
   backendCache <- liftIO newBackendCache
@@ -133,11 +109,10 @@ tryPluginInitLLM opts = do
   let st = PluginState
         { candidates     = []
         , writeLogEvent  = logger
-        , templateSpec   = spec
         , configuration  = config
         , serviceCallOps = ops
         }
-  debugMsg st $ "running with flags: " <> T.pack (show flags)
+  lift $ debugMsg st $ "running with flags: " <> T.pack (show flags)
   pure st
 
 
@@ -153,7 +128,7 @@ tryPluginInitLLM opts = do
 -- This wrapper launches the hole fit process
 -- and catches any errors.
 fitPluginLLM
-  :: TcRef (Either PluginError PluginState)
+  :: TcRef (Either PluginError (PluginState TcM))
   -> TypedHole
   -> [HoleFit] -- Known hole fits from GHC
   -> TcM [HoleFit]
@@ -169,7 +144,7 @@ fitPluginLLM ref hole fits = do
       pure fits
 
 tryFitPluginLLM
-  :: PluginState -> TypedHole -> [HoleFit]
+  :: PluginState TcM -> TypedHole -> [HoleFit]
   -> ExceptT PluginError TcM [HoleFit]
 tryFitPluginLLM st typedHole fits = do
   withTypedHole typedHole $ \hole -> do
@@ -195,7 +170,7 @@ holeTriggerName =
   T.pack . occNameString . rdrNameOcc . hole_occ
 
 buildPromptContext
-  :: PluginState -> TypedHole -> [HoleFit]
+  :: PluginState TcM -> TypedHole -> [HoleFit]
   -> ExceptT PluginError TcM PromptContext
 buildPromptContext st hole fits = do
   gblEnv <- lift getGblEnv
@@ -210,13 +185,13 @@ buildPromptContext st hole fits = do
 
 -- TODO: need to log individual responses properly
 extractHoleFitsFromPromptResponses
-  :: PluginState -> [PromptResponse] -> TypedHole -> Hole -> TcM [HoleFit]
+  :: PluginState TcM -> [PromptResponse] -> TypedHole -> Hole -> TcM [HoleFit]
 extractHoleFitsFromPromptResponses st resps th hole =
   let resp = mconcat [txt | PromptResponse txt <- resps]
   in extractHoleFitsFromResponse st mempty resp th hole
 
 extractHoleFitsFromResponse
-  :: PluginState -> Log.Prompt -> Log.Response
+  :: PluginState TcM -> Log.Prompt -> Log.Response
   -> TypedHole -> Hole -> TcM [HoleFit]
 extractHoleFitsFromResponse st prompt rsp hole h = do
   let logger = writeLogEvent st
@@ -414,14 +389,6 @@ getDocs cs = do
 
 -- Utils
 --------
-
-debugMsg :: (MonadIO m) => PluginState -> Text -> m ()
-debugMsg st txt = liftIO $ when (isDebugMode st) $
-  T.putStrLn $ pluginName <> ": " <> txt
-
-warnMsg :: (MonadIO m) => PluginState -> Text -> m ()
-warnMsg st txt = liftIO $ when (isDebugMode st) $
-  T.putStrLn $ pluginName <> ": " <> txt
 
 liftEitherIO :: (MonadIO m) => (e1 -> e2) -> IO (Either e1 a) -> ExceptT e2 m a
 liftEitherIO f act = liftIO act >>= either (throwError . f) pure

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -47,7 +47,6 @@ import GHC.Tc.Utils.TcType qualified as GHC (tyCoFVsOfType, mkPhiTy)
 import GHC.Tc.Solver qualified as GHC (simplifyTop, simplifyInfer, captureTopConstraints, InferMode(..))
 import GHC.Tc.Solver.Monad qualified as GHC (zonkTcType, runTcSEarlyAbort)
 
-import GHC.Plugin.OllamaHoles.Backend
 import GHC.Plugin.OllamaHoles.Data.Flags
 import GHC.Plugin.OllamaHoles.Prompt
 import GHC.Plugin.OllamaHoles.Logger qualified as Log
@@ -58,6 +57,7 @@ import GHC.Plugin.OllamaHoles.Data.ServiceCall
 import GHC.Plugin.OllamaHoles.Data.PluginState
 import GHC.Plugin.OllamaHoles.Runtime
 import GHC.Plugin.OllamaHoles.Constants
+import GHC.Plugin.OllamaHoles.Console
 
 
 
@@ -70,9 +70,8 @@ plugin = defaultPlugin
 mkHoleFitPluginR
   :: [CommandLineOption] -> HoleFitPluginR
 mkHoleFitPluginR opts = HoleFitPluginR
-  { hfPluginInit =
-      -- Initialize the plugin (this may fail).
-      hfPluginInitLLM opts :: TcM (TcRef (Either PluginError (PluginState TcM)))
+  -- Initialize the plugin (this may fail).
+  { hfPluginInit = hfPluginInitLLM opts
   , hfPluginStop = \_ -> return ()
   , hfPluginRun = \ref -> HoleFitPlugin
     { candPlugin = \_ cs -> updTcRef ref (fmap (setCandidates cs)) >> return cs
@@ -389,11 +388,3 @@ getDocs cs = do
 
 liftEitherIO :: (MonadIO m) => (e1 -> e2) -> IO (Either e1 a) -> ExceptT e2 m a
 liftEitherIO f act = liftIO act >>= either (throwError . f) pure
-
-printRenderedError
-  :: (MonadIO m) => Either PluginError u -> m (Either PluginError u)
-printRenderedError x = case x of
-  Right u -> pure (Right u)
-  Left err -> do
-    liftIO $ T.putStrLn $ renderPluginError err
-    pure (Left err)

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -47,12 +47,10 @@ import GHC.Tc.Utils.TcType qualified as GHC (tyCoFVsOfType, mkPhiTy)
 import GHC.Tc.Solver qualified as GHC (simplifyTop, simplifyInfer, captureTopConstraints, InferMode(..))
 import GHC.Tc.Solver.Monad qualified as GHC (zonkTcType, runTcSEarlyAbort)
 
-import GHC.Plugin.OllamaHoles.Data.Flags
 import GHC.Plugin.OllamaHoles.Prompt
 import GHC.Plugin.OllamaHoles.Logger qualified as Log
 import GHC.Plugin.OllamaHoles.Candidate
 import GHC.Plugin.OllamaHoles.Error
-import GHC.Plugin.OllamaHoles.Data.Config
 import GHC.Plugin.OllamaHoles.Data.ServiceCall
 import GHC.Plugin.OllamaHoles.Data.PluginState
 import GHC.Plugin.OllamaHoles.Runtime
@@ -87,29 +85,9 @@ mkHoleFitPluginR opts = HoleFitPluginR
 hfPluginInitLLM
   :: [CommandLineOption]
   -> TcM (TcRef (Either PluginError (PluginState TcM)))
-hfPluginInitLLM =
-  (runExceptT . tryPluginInitLLM)
-    >=> printRenderedError >=> newTcRef
+hfPluginInitLLM = pluginInit >=> newTcRef
 
--- | Initialize the plugin state
-tryPluginInitLLM
-  :: [CommandLineOption] -> ExceptT PluginError TcM (PluginState TcM)
-tryPluginInitLLM opts = do
-  flags <- case parseFlags opts of
-    Right (fs, []) -> pure fs
-    Right (_, unk) -> throwError $ UnknownOptionError unk
-    Left err       -> throwError $ OptionParseError err
-  logger <- liftIO $ Log.initLogger (log_mode flags) (log_dir flags)
-  config <- modifyError SomeConfigError $ buildConfig flags
-  ops <- lift newServiceCallOps
-  let st = PluginState
-        { candidates     = []
-        , writeLogEvent  = logger
-        , configuration  = config
-        , serviceCallOps = ops
-        }
-  lift $ debugMsg st $ "running with flags: " <> T.pack (show flags)
-  pure st
+
 
 
 

--- a/src/GHC/Plugin/OllamaHoles.hs
+++ b/src/GHC/Plugin/OllamaHoles.hs
@@ -95,7 +95,6 @@ data PluginState = PluginState
   { candidates     :: [HoleFitCandidate]
   , writeLogEvent  :: Log.Logger
   , templateSpec   :: TemplateSpec
-  , parsedTemplate :: Template
   , configuration  :: Config
   , serviceCallOps :: ServiceCallOps TcM
   }
@@ -128,7 +127,6 @@ tryPluginInitLLM opts = do
     Left err       -> throwError $ OptionParseError err
   spec <- liftEitherIO TemplateSpecError $ pure $ mkTemplateSpec flags
   logger <- liftIO $ Log.initLogger (log_mode flags) (log_dir flags)
-  template <- liftEitherIO TemplateParseError $ loadTemplate spec
   config <- modifyError SomeConfigError $ buildConfig flags
   backendCache <- liftIO newBackendCache
   let ops = mkServiceCallOps backendCache
@@ -136,7 +134,6 @@ tryPluginInitLLM opts = do
         { candidates     = []
         , writeLogEvent  = logger
         , templateSpec   = spec
-        , parsedTemplate = template
         , configuration  = config
         , serviceCallOps = ops
         }

--- a/src/GHC/Plugin/OllamaHoles/Console.hs
+++ b/src/GHC/Plugin/OllamaHoles/Console.hs
@@ -1,0 +1,34 @@
+module GHC.Plugin.OllamaHoles.Console
+  ( debugMsg
+  , warnMsg
+  , printRenderedError
+  ) where
+
+import Control.Monad (when)
+import Control.Monad.IO.Class (MonadIO(..))
+import Data.Text (Text)
+import Data.Text.IO qualified as T
+
+import GHC.Plugin.OllamaHoles.Constants
+import GHC.Plugin.OllamaHoles.Error
+import GHC.Plugin.OllamaHoles.Data.PluginState
+
+
+
+debugMsg :: (MonadIO m) => PluginState u -> Text -> m ()
+debugMsg st txt = liftIO $ when (isDebugMode st) $
+  T.putStrLn $ pluginName <> ": " <> txt
+
+warnMsg :: (MonadIO m) => PluginState u -> Text -> m ()
+warnMsg st txt = liftIO $ when (isDebugMode st) $
+  T.putStrLn $ pluginName <> ": " <> txt
+
+
+
+printRenderedError
+  :: (MonadIO m) => Either PluginError u -> m (Either PluginError u)
+printRenderedError x = case x of
+  Right u -> pure (Right u)
+  Left err -> do
+    liftIO $ T.putStrLn $ renderPluginError err
+    pure (Left err)

--- a/src/GHC/Plugin/OllamaHoles/Constants.hs
+++ b/src/GHC/Plugin/OllamaHoles/Constants.hs
@@ -1,0 +1,40 @@
+module GHC.Plugin.OllamaHoles.Constants where
+
+import Data.Text (Text)
+
+import GHC.Plugin.OllamaHoles.Backend
+import GHC.Plugin.OllamaHoles.Data.Flags
+
+
+
+pluginName :: Text
+pluginName = "Ollama Plugin"
+
+
+
+defaultModelName :: Text
+defaultModelName = "qwen3:latest"
+
+defaultBackendName :: BackendSlug
+defaultBackendName = Ollama
+
+defaultNumExpr :: Int
+defaultNumExpr = 5
+
+defaultDebug :: Bool
+defaultDebug = True
+
+defaultIncludeDocs :: Bool
+defaultIncludeDocs = True
+
+defaultConfigPath :: ConfigPathSpec
+defaultConfigPath = ConfigDefault
+
+defaultOpenAIBaseUrl :: Text
+defaultOpenAIBaseUrl = "https://api.openai.com"
+
+defaultOpenAIKeyName :: Text
+defaultOpenAIKeyName = "OPENAI_API_KEY"
+
+defaultTemplateSearchDir :: Text
+defaultTemplateSearchDir = "."

--- a/src/GHC/Plugin/OllamaHoles/Data/PluginState.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/PluginState.hs
@@ -1,0 +1,5 @@
+module GHC.Plugin.OllamaHoles.Data.PluginState
+  ( module GHC.Plugin.OllamaHoles.Data.PluginState.Types
+  ) where
+
+import GHC.Plugin.OllamaHoles.Data.PluginState.Types

--- a/src/GHC/Plugin/OllamaHoles/Data/PluginState/Types.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/PluginState/Types.hs
@@ -1,0 +1,44 @@
+module GHC.Plugin.OllamaHoles.Data.PluginState.Types
+  ( PluginState(..)
+  , setCandidates
+  , isDebugMode
+  , debugMsg
+  , warnMsg
+  , pluginName
+  ) where
+
+import Control.Monad (when)
+import Control.Monad.IO.Class (MonadIO(..))
+import Data.Text (Text)
+import Data.Text.IO qualified as T
+import GHC.Tc.Errors.Hole.FitTypes (HoleFitCandidate)
+
+import GHC.Plugin.OllamaHoles.Logger qualified as Log
+import GHC.Plugin.OllamaHoles.Data.Config
+import GHC.Plugin.OllamaHoles.Data.ServiceCall
+
+
+
+data PluginState m = PluginState
+  { candidates     :: [HoleFitCandidate]
+  , writeLogEvent  :: Log.Logger
+  , configuration  :: Config
+  , serviceCallOps :: ServiceCallOps m
+  }
+
+setCandidates :: [HoleFitCandidate] -> PluginState m -> PluginState m
+setCandidates cs st = st { candidates = cs }
+
+isDebugMode :: PluginState m -> Bool
+isDebugMode = configDebug . configuration
+
+debugMsg :: (MonadIO m) => PluginState m' -> Text -> m ()
+debugMsg st txt = liftIO $ when (isDebugMode st) $
+  T.putStrLn $ pluginName <> ": " <> txt
+
+warnMsg :: (MonadIO m) => PluginState m' -> Text -> m ()
+warnMsg st txt = liftIO $ when (isDebugMode st) $
+  T.putStrLn $ pluginName <> ": " <> txt
+
+pluginName :: Text
+pluginName = "Ollama Plugin"

--- a/src/GHC/Plugin/OllamaHoles/Data/PluginState/Types.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/PluginState/Types.hs
@@ -2,20 +2,13 @@ module GHC.Plugin.OllamaHoles.Data.PluginState.Types
   ( PluginState(..)
   , setCandidates
   , isDebugMode
-  , debugMsg
-  , warnMsg
   ) where
 
-import Control.Monad (when)
-import Control.Monad.IO.Class (MonadIO(..))
-import Data.Text (Text)
-import Data.Text.IO qualified as T
 import GHC.Tc.Errors.Hole.FitTypes (HoleFitCandidate)
 
 import GHC.Plugin.OllamaHoles.Logger qualified as Log
 import GHC.Plugin.OllamaHoles.Data.Config
 import GHC.Plugin.OllamaHoles.Data.ServiceCall
-import GHC.Plugin.OllamaHoles.Constants
 
 
 
@@ -31,13 +24,3 @@ setCandidates cs st = st { candidates = cs }
 
 isDebugMode :: PluginState m -> Bool
 isDebugMode = configDebug . configuration
-
-
-
-debugMsg :: (MonadIO m) => PluginState m' -> Text -> m ()
-debugMsg st txt = liftIO $ when (isDebugMode st) $
-  T.putStrLn $ pluginName <> ": " <> txt
-
-warnMsg :: (MonadIO m) => PluginState m' -> Text -> m ()
-warnMsg st txt = liftIO $ when (isDebugMode st) $
-  T.putStrLn $ pluginName <> ": " <> txt

--- a/src/GHC/Plugin/OllamaHoles/Data/PluginState/Types.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/PluginState/Types.hs
@@ -4,7 +4,6 @@ module GHC.Plugin.OllamaHoles.Data.PluginState.Types
   , isDebugMode
   , debugMsg
   , warnMsg
-  , pluginName
   ) where
 
 import Control.Monad (when)
@@ -16,6 +15,7 @@ import GHC.Tc.Errors.Hole.FitTypes (HoleFitCandidate)
 import GHC.Plugin.OllamaHoles.Logger qualified as Log
 import GHC.Plugin.OllamaHoles.Data.Config
 import GHC.Plugin.OllamaHoles.Data.ServiceCall
+import GHC.Plugin.OllamaHoles.Constants
 
 
 
@@ -32,6 +32,8 @@ setCandidates cs st = st { candidates = cs }
 isDebugMode :: PluginState m -> Bool
 isDebugMode = configDebug . configuration
 
+
+
 debugMsg :: (MonadIO m) => PluginState m' -> Text -> m ()
 debugMsg st txt = liftIO $ when (isDebugMode st) $
   T.putStrLn $ pluginName <> ": " <> txt
@@ -39,6 +41,3 @@ debugMsg st txt = liftIO $ when (isDebugMode st) $
 warnMsg :: (MonadIO m) => PluginState m' -> Text -> m ()
 warnMsg st txt = liftIO $ when (isDebugMode st) $
   T.putStrLn $ pluginName <> ": " <> txt
-
-pluginName :: Text
-pluginName = "Ollama Plugin"

--- a/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit.hs
+++ b/src/GHC/Plugin/OllamaHoles/Data/ServiceCall/Submit.hs
@@ -25,8 +25,8 @@ import GHC.Plugin.OllamaHoles.Data.ServiceCall.Route
 
 
 submitServiceCallWithBackend
-  :: Backend -> PromptRequest -> ServiceCall
-  -> ExceptT ServiceCallError TcM PromptResponse
+  :: (MonadIO m) => Backend -> PromptRequest -> ServiceCall
+  -> ExceptT ServiceCallError m PromptResponse
 submitServiceCallWithBackend backend req caller = do
   prompt <- renderPromptForServiceCall req caller
   let
@@ -40,7 +40,7 @@ submitServiceCallWithBackend backend req caller = do
     Right response -> pure $ PromptResponse response
 
 renderPromptForServiceCall
-  :: PromptRequest -> ServiceCall -> ExceptT ServiceCallError TcM Text
+  :: (Monad m) => PromptRequest -> ServiceCall -> ExceptT ServiceCallError m Text
 renderPromptForServiceCall req caller = do
   let template = requestTemplate req
   let docs = mempty

--- a/src/GHC/Plugin/OllamaHoles/Runtime.hs
+++ b/src/GHC/Plugin/OllamaHoles/Runtime.hs
@@ -1,0 +1,5 @@
+module GHC.Plugin.OllamaHoles.Runtime
+  ( module GHC.Plugin.OllamaHoles.Runtime.Ops
+  ) where
+
+import GHC.Plugin.OllamaHoles.Runtime.Ops

--- a/src/GHC/Plugin/OllamaHoles/Runtime.hs
+++ b/src/GHC/Plugin/OllamaHoles/Runtime.hs
@@ -1,5 +1,7 @@
 module GHC.Plugin.OllamaHoles.Runtime
   ( module GHC.Plugin.OllamaHoles.Runtime.Ops
+  , module GHC.Plugin.OllamaHoles.Runtime.Init
   ) where
 
 import GHC.Plugin.OllamaHoles.Runtime.Ops
+import GHC.Plugin.OllamaHoles.Runtime.Init

--- a/src/GHC/Plugin/OllamaHoles/Runtime/Init.hs
+++ b/src/GHC/Plugin/OllamaHoles/Runtime/Init.hs
@@ -1,0 +1,45 @@
+module GHC.Plugin.OllamaHoles.Runtime.Init
+  ( pluginInit
+  ) where
+
+import Control.Monad ((>=>))
+import Control.Monad.Except
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.Trans.Class (MonadTrans(..))
+import Data.Text qualified as T
+import GHC.Plugins (CommandLineOption)
+
+import GHC.Plugin.OllamaHoles.Logger qualified as Log
+import GHC.Plugin.OllamaHoles.Error
+import GHC.Plugin.OllamaHoles.Console
+import GHC.Plugin.OllamaHoles.Data.Flags
+import GHC.Plugin.OllamaHoles.Data.Config
+import GHC.Plugin.OllamaHoles.Runtime.Ops
+import GHC.Plugin.OllamaHoles.Data.PluginState
+
+
+
+pluginInit
+  :: (MonadIO m) => [CommandLineOption]
+  -> m (Either PluginError (PluginState m))
+pluginInit = (runExceptT . tryPluginInit) >=> printRenderedError
+
+-- | Initialize the plugin state
+tryPluginInit
+  :: (MonadIO m) => [CommandLineOption] -> ExceptT PluginError m (PluginState m)
+tryPluginInit opts = do
+  flags <- case parseFlags opts of
+    Right (fs, []) -> pure fs
+    Right (_, unk) -> throwError $ UnknownOptionError unk
+    Left err       -> throwError $ OptionParseError err
+  logger <- liftIO $ Log.initLogger (log_mode flags) (log_dir flags)
+  config <- modifyError SomeConfigError $ buildConfig flags
+  ops <- lift newServiceCallOps
+  let st = PluginState
+        { candidates     = []
+        , writeLogEvent  = logger
+        , configuration  = config
+        , serviceCallOps = ops
+        }
+  lift $ debugMsg st $ "running with flags: " <> T.pack (show flags)
+  pure st

--- a/src/GHC/Plugin/OllamaHoles/Runtime/Ops.hs
+++ b/src/GHC/Plugin/OllamaHoles/Runtime/Ops.hs
@@ -1,0 +1,63 @@
+module GHC.Plugin.OllamaHoles.Runtime.Ops
+  ( newServiceCallOps
+  ) where
+
+import Control.Monad.IO.Class (MonadIO(..))
+import Data.Map qualified as M
+import GHC.IORef
+
+import GHC.Plugin.OllamaHoles.Backend
+import GHC.Plugin.OllamaHoles.Data.Service
+import GHC.Plugin.OllamaHoles.Data.Profile
+import GHC.Plugin.OllamaHoles.Data.ServiceCall
+
+
+
+-- | This type is only used internally.
+newtype BackendCache = BackendCache
+  { unBackendCache :: IORef (M.Map BackendConfig Backend)
+  }
+
+newBackendCache :: IO BackendCache
+newBackendCache =
+  BackendCache <$> newIORef M.empty
+
+
+
+newServiceCallOps :: (MonadIO m) => m (ServiceCallOps m)
+newServiceCallOps =
+  fmap mkServiceCallOps $ liftIO newBackendCache
+
+mkServiceCallOps
+  :: (MonadIO m) => BackendCache -> ServiceCallOps m
+mkServiceCallOps backendCache = ServiceCallOps
+  { opsListModels = \service -> liftIO $ do
+      backend <- backendForService backendCache service
+      fmap (map ModelName) <$> listModels backend
+
+  , opsGetServiceCallTemplate = getServiceCallTemplate
+
+  , opsSubmitServiceCall = \request call -> do
+      backend <- liftIO $
+        backendForService backendCache (callService call)
+      submitServiceCallWithBackend backend request call
+  }
+
+backendForService
+  :: BackendCache -> Service -> IO Backend
+backendForService cache service =
+  backendForConfig cache (svcConfig service)
+
+backendForConfig
+  :: BackendCache -> BackendConfig -> IO Backend
+backendForConfig bc config = do
+  let ref = unBackendCache bc
+  cache <- readIORef ref
+  case M.lookup config cache of
+    Just backend -> pure backend
+    Nothing -> do
+      let backend = configureBackend config
+      atomicModifyIORef' ref $ \cache0 ->
+        ( M.insert config backend cache0
+        , backend
+        )


### PR DESCRIPTION
After implementing the Config feature, PluginState could use a tidy.

- parsedTemplate is no longer used
- templateSpec is no longer used
- PluginState is much less special, can be moved to the library