### PR TITLE
Loosen dependency bounds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -138,6 +138,60 @@ jobs:
           2>&1 | tee demo-build.log || true
         grep "Valid hole fits" demo-build.log
 
+  ollama-haskell-compat:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ghc: '9.12'
+            ollama-haskell: '0.1.3.0'
+          - ghc: '9.12'
+            ollama-haskell: '0.2.0.0'
+
+    name: ollama-haskell ${{ matrix.ollama-haskell }} with GHC ${{ matrix.ghc }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Cabal/GHC
+      id: setup-haskell
+      uses: haskell-actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: 'latest'
+
+    - name: Cache Cabal
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cabal/packages
+          ${{ steps.setup-haskell.outputs.cabal-store }}
+          ~/.cabal/bin
+          dist-newstyle
+        key: compat-${{ runner.os }}-ghc-${{ matrix.ghc }}-ollama-haskell-${{ matrix.ollama-haskell }}-${{ hashFiles('**/*.cabal', 'cabal.project') }}
+        restore-keys: |
+          compat-${{ runner.os }}-ghc-${{ matrix.ghc }}-ollama-haskell-${{ matrix.ollama-haskell }}-
+          build-${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-
+
+    - name: Update cabal index
+      run: cabal update
+
+    - name: Pin ollama-haskell
+      run: |
+        cat > cabal.project.local <<EOF
+        constraints: ollama-haskell == ${{ matrix.ollama-haskell }}
+        EOF
+
+    - name: Build Haskell project
+      run: cabal build lib:ollama-holes-lib lib:ollama-holes-plugin
+
+    - name: Run spec tests
+      run: cabal test ollama-holes-spec --test-options='--hide-successes'
+
+
 # Notes
 # =====
 

--- a/ollama-holes-demo/ollama-holes-demo.cabal
+++ b/ollama-holes-demo/ollama-holes-demo.cabal
@@ -18,7 +18,7 @@ author:             Matthias Pall Gissurarson <mpg@mpg.is>
 maintainer:         Matthias Pall Gissurarson <mpg@mpg.is>
 copyright:          2025 (c) Matthias Pall Gissurarson  
 category:           Development, Compiler Plugin
-tested-with:        GHC == 9.10.*, GHC == 9.12.*
+tested-with:        GHC == 9.6.*, GHC == 9.8.*, GHC == 9.10.*, GHC == 9.12.*
 build-type:         Simple
 extra-doc-files:    ../CHANGELOG.md
                     ../README.md

--- a/ollama-holes-plugin/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin/ollama-holes-plugin.cabal
@@ -96,7 +96,6 @@ common shared-base
     , aeson ^>= 2.2
     , bytestring >= 0.11.5 && < 0.13
     , containers >= 0.6 && < 0.8
-    , crypton >= 1.1.2
     , directory >= 1.3.8 && < 1.4
     , filepath >= 1.4.2 && < 1.6
     , ghc >= 9.6 && < 9.14
@@ -111,7 +110,7 @@ common shared-base
 common backend-deps
   build-depends:
       modern-uri ^>= 0.3
-    , ollama-haskell ^>= 0.1
+    , ollama-haskell >= 0.1
     , req ^>= 3.13
 
 library

--- a/ollama-holes-plugin/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin/ollama-holes-plugin.cabal
@@ -72,7 +72,7 @@ author:             Matthias Pall Gissurarson <mpg@mpg.is>
 maintainer:         Matthias Pall Gissurarson <mpg@mpg.is>
 copyright:          2025 (c) Matthias Pall Gissurarson  
 category:           Development, Compiler Plugin
-tested-with:        GHC == 9.10.*, GHC == 9.12.*
+tested-with:        GHC == 9.6.*, GHC == 9.8.*, GHC == 9.10.*, GHC == 9.12.*
 build-type:         Simple
 extra-doc-files:    ../CHANGELOG.md
                     ../README.md
@@ -110,7 +110,7 @@ common shared-base
 common backend-deps
   build-depends:
       modern-uri ^>= 0.3
-    , ollama-haskell >= 0.1
+    , ollama-haskell >= 0.1 && < 0.3
     , req ^>= 3.13
 
 library

--- a/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Backend/Ollama.hs
+++ b/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Backend/Ollama.hs
@@ -29,16 +29,17 @@ data OllamaConfig = OllamaConfig
 
 -- | The locally hosted ollama backend
 ollamaBackend :: OllamaConfig -> Backend
-ollamaBackend _ = Backend
-  { listModels = listOllamaModels
-  , generateFits = generateOllamaFits
+ollamaBackend conf = Backend
+  { listModels = listOllamaModels conf
+  , generateFits = generateOllamaFits conf
   }
 
-listOllamaModels :: IO (Maybe [Text])
-listOllamaModels = do
+listOllamaModels :: OllamaConfig -> IO (Maybe [Text])
+listOllamaModels conf = do
   listAll <- do
 #if MIN_VERSION_ollama_haskell(0,2,0)
-    result <- Ollama.list Nothing
+    let conf' = parseOllamaConfig conf
+    result <- Ollama.list (Just conf')
     pure $ case result of
       Left _ -> Nothing
       Right ok -> Just ok
@@ -48,9 +49,19 @@ listOllamaModels = do
   let getMs (Ollama.Models models) = fmap Ollama.name models
   pure $ fmap getMs listAll
 
+#if MIN_VERSION_ollama_haskell(0,2,0)
+parseOllamaConfig :: OllamaConfig -> Ollama.OllamaConfig
+parseOllamaConfig conf = setHost Ollama.defaultOllamaConfig
+  where
+    setHost :: Ollama.OllamaConfig -> Ollama.OllamaConfig
+    setHost x = case svcOllamaHost conf of
+      Nothing -> x
+      Just hs -> x { Ollama.hostUrl = hs }
+#endif
+
 generateOllamaFits
-  :: Text -> Text -> Maybe Value -> IO (Either String Text)
-generateOllamaFits prompt modelName options = do
+  :: OllamaConfig -> Text -> Text -> Maybe Value -> IO (Either String Text)
+generateOllamaFits conf prompt modelName options = do
   let ops = Ollama.defaultGenerateOps
         { prompt = prompt
         , modelName = modelName

--- a/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Backend/Ollama.hs
+++ b/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Backend/Ollama.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE CPP #-}
 
 -- | The locally hosted ollama backend
 module GHC.Plugin.OllamaHoles.Backend.Ollama
@@ -7,6 +8,10 @@ module GHC.Plugin.OllamaHoles.Backend.Ollama
   ) where
 
 import GHC.Generics (Generic)
+import Data.Aeson (Value, FromJSON, Value(..))
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Aeson.Types (parseMaybe, parseJSON)
 import Data.Text (Text)
 
 import Ollama (GenerateOps (..))
@@ -24,12 +29,73 @@ data OllamaConfig = OllamaConfig
 
 -- | The locally hosted ollama backend
 ollamaBackend :: OllamaConfig -> Backend
-ollamaBackend _ = Backend{..}
-  where
-    listModels = fmap getMs <$> Ollama.list
-    getMs (Ollama.Models models) = fmap Ollama.name models
-    generateFits prompt modelName options = do
-        fmap Ollama.response_ <$> Ollama.generate Ollama.defaultGenerateOps{prompt = prompt,
-                                                                            modelName = modelName,
-                                                                            options = options}
+ollamaBackend _ = Backend
+  { listModels = listOllamaModels
+  , generateFits = generateOllamaFits
+  }
 
+listOllamaModels :: IO (Maybe [Text])
+listOllamaModels = do
+  listAll <- do
+#if MIN_VERSION_text(2,0,0)
+    result <- Ollama.list Nothing
+    pure $ case result of
+      Left _ -> Nothing
+      Right ok -> Just ok
+#else
+    Ollama.list
+#endif
+  let getMs (Ollama.Models models) = fmap Ollama.name models
+  pure $ fmap getMs listAll
+
+generateOllamaFits
+  :: Text -> Text -> Maybe Value -> IO (Either String Text)
+generateOllamaFits prompt modelName options = do
+  let ops = Ollama.defaultGenerateOps
+        { prompt = prompt
+        , modelName = modelName
+        }
+#if MIN_VERSION_text(2,0,0)
+  let
+    parseModelOptions :: Value -> Ollama.ModelOptions
+    parseModelOptions v = Ollama.ModelOptions
+      { numKeep = extractAtKey "num_keep" v
+      , seed = extractAtKey "seed" v
+      , numPredict = extractAtKey "num_predict" v
+      , topK = extractAtKey "top_k" v
+      , topP = extractAtKey "top_p" v
+      , minP = extractAtKey "min_p" v
+      , typicalP = extractAtKey "typical_p" v
+      , repeatLastN = extractAtKey "repeat_last_n" v
+      , temperature = extractAtKey "temperature" v
+      , repeatPenalty = extractAtKey "repeat_penalty" v
+      , presencePenalty = extractAtKey "presence_penalty" v
+      , frequencyPenalty = extractAtKey "frequency_penalty" v
+      , penalizeNewline = extractAtKey "penalize_newline" v
+      , stop = extractAtKey "stop" v
+      , numa = extractAtKey "numa" v
+      , numCtx = extractAtKey "num_ctx" v
+      , numBatch = extractAtKey "num_batch" v
+      , numGpu = extractAtKey "num_gpu" v
+      , mainGpu = extractAtKey "main_gpu" v
+      , useMmap = extractAtKey "use_mmap" v
+      , numThread = extractAtKey "num_thread" v
+      }
+
+    ops' = ops { options = fmap parseModelOptions options }
+  result <- fmap Ollama.genResponse <$> Ollama.generate ops Nothing
+  pure $ case result of
+    Right ok -> Right ok
+    Left err -> Left $ show err
+#else
+  let ops' = ops { options = options }
+  fmap Ollama.response_ <$> Ollama.generate ops'
+#endif
+
+
+
+extractAtKey :: FromJSON a => String -> Value -> Maybe a
+extractAtKey key = \case
+  Object obj -> KeyMap.lookup (Key.fromString key) obj
+    >>= parseMaybe parseJSON
+  _ -> Nothing

--- a/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Backend/Ollama.hs
+++ b/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Backend/Ollama.hs
@@ -37,7 +37,7 @@ ollamaBackend _ = Backend
 listOllamaModels :: IO (Maybe [Text])
 listOllamaModels = do
   listAll <- do
-#if MIN_VERSION_text(2,0,0)
+#if MIN_VERSION_ollama_haskell(0,2,0)
     result <- Ollama.list Nothing
     pure $ case result of
       Left _ -> Nothing
@@ -55,7 +55,7 @@ generateOllamaFits prompt modelName options = do
         { prompt = prompt
         , modelName = modelName
         }
-#if MIN_VERSION_text(2,0,0)
+#if MIN_VERSION_ollama_haskell(0,2,0)
   let
     parseModelOptions :: Value -> Ollama.ModelOptions
     parseModelOptions v = Ollama.ModelOptions
@@ -83,7 +83,7 @@ generateOllamaFits prompt modelName options = do
       }
 
     ops' = ops { options = fmap parseModelOptions options }
-  result <- fmap Ollama.genResponse <$> Ollama.generate ops Nothing
+  result <- fmap Ollama.genResponse <$> Ollama.generate ops' Nothing
   pure $ case result of
     Right ok -> Right ok
     Left err -> Left $ show err

--- a/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Logger.hs
+++ b/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Logger.hs
@@ -12,17 +12,18 @@ module GHC.Plugin.OllamaHoles.Logger
 
 
 import           Control.Monad (unless)
-import qualified Crypto.Hash as H
 import           Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import           Data.Aeson.Encoding (pairs, encodingToLazyByteString)
+import           Data.Bits (xor)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
+import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import           Data.Time.Clock (getCurrentTime)
 import           Data.Time.Format (defaultTimeLocale, formatTime)
-import           Data.Word (Word32)
+import           Data.Word (Word8, Word32, Word64)
 import           GHC.Generics (Generic)
 import           Numeric (showHex)
 import           System.Directory
@@ -72,8 +73,8 @@ renderLogEvent
     :: Timestamp -> LogConfig -> LogEvent
     -> (LBS.ByteString, PromptHash, ResponseHash)
 renderLogEvent now config event =
-    let promptHash = contentHash $ lePrompt event
-        responseHash = contentHash $ leResponse event
+    let promptHash = contentHashText $ lePrompt event
+        responseHash = contentHashText $ leResponse event
 
         enc :: Aeson.Encoding
         enc =
@@ -159,10 +160,6 @@ getFormattedTimestamp :: IO Timestamp
 getFormattedTimestamp = do
   now <- getCurrentTime
   pure . T.pack $ formatTime defaultTimeLocale "%Y-%m-%d_%H:%M:%S" now
-
-contentHash :: T.Text -> T.Text
-contentHash =
-  T.pack . show . (H.hash . TE.encodeUtf8 :: T.Text -> H.Digest H.SHA256)
 
 
 
@@ -251,3 +248,21 @@ eventsFileForSession :: LogPaths -> FilePath
 eventsFileForSession paths =
     let dir = lpRootDir paths
     in dropTrailingPathSeparator dir </> "hole-fit-logs.jsonl"
+
+
+
+-- Utils
+
+contentHashText :: Text -> Text
+contentHashText = T.pack . hex64 . fnv1a64 . TE.encodeUtf8
+
+fnv1a64 :: BS.ByteString -> Word64
+fnv1a64 = BS.foldl' step 0xcbf29ce484222325
+  where
+    step :: Word64 -> Word8 -> Word64
+    step h b = (h `xor` fromIntegral b) * 0x100000001b3
+
+hex64 :: Word64 -> String
+hex64 w =
+  let s = showHex w ""
+  in replicate (16 - length s) '0' <> s


### PR DESCRIPTION
This patch removes the crypton dependency, which was only used for its' hash function for content addressing in logs, and also loosens the bound on ollama-haskell to support a wider range of client configurations.