### PR TITLE
Add Static backend for tests

### DIFF
--- a/ollama-holes-plugin/ollama-holes-plugin.cabal
+++ b/ollama-holes-plugin/ollama-holes-plugin.cabal
@@ -138,6 +138,7 @@ library ollama-holes-lib
     , GHC.Plugin.OllamaHoles.Backend.Ollama
     , GHC.Plugin.OllamaHoles.Backend.OpenAI
     , GHC.Plugin.OllamaHoles.Backend.Gemini
+    , GHC.Plugin.OllamaHoles.Backend.Static
     , GHC.Plugin.OllamaHoles.Candidate
     , GHC.Plugin.OllamaHoles.Candidate.Compat
     , GHC.Plugin.OllamaHoles.Candidate.Rewrite
@@ -198,7 +199,8 @@ test-suite ollama-holes-spec
   main-is:             Main.hs
   hs-source-dirs:      spec
   other-modules:
-      GHC.Plugin.OllamaHoles.Candidate.Spec
+      GHC.Plugin.OllamaHoles.Backend.Static.Spec
+    , GHC.Plugin.OllamaHoles.Candidate.Spec
     , GHC.Plugin.OllamaHoles.Candidate.Compat.Spec
     , GHC.Plugin.OllamaHoles.Candidate.Normalize.Spec
     , GHC.Plugin.OllamaHoles.Candidate.Rewrite.Spec

--- a/ollama-holes-plugin/spec/GHC/Plugin/OllamaHoles/Backend/Static/Spec.hs
+++ b/ollama-holes-plugin/spec/GHC/Plugin/OllamaHoles/Backend/Static/Spec.hs
@@ -7,7 +7,6 @@ import Data.Text.IO qualified as T
 import System.FilePath ((</>))
 import Test.Tasty
 import Test.Tasty.HUnit
-import Test.Tasty.QuickCheck ()
 import System.IO.Temp (withSystemTempDirectory)
 
 import GHC.Plugin.OllamaHoles.Backend.Common

--- a/ollama-holes-plugin/spec/GHC/Plugin/OllamaHoles/Backend/Static/Spec.hs
+++ b/ollama-holes-plugin/spec/GHC/Plugin/OllamaHoles/Backend/Static/Spec.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module GHC.Plugin.OllamaHoles.Backend.Static.Spec (tests) where
+
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
+import System.FilePath ((</>))
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck ()
+import System.IO.Temp (withSystemTempDirectory)
+
+import GHC.Plugin.OllamaHoles.Backend.Common
+import GHC.Plugin.OllamaHoles.Backend.Static
+
+tests :: TestTree
+tests = testGroup "GHC.Plugin.OllamaHoles.Backend.Static"
+  [ testCase "returns inline static response" testInlineResponse
+  , testCase "returns file static response" testFileResponse
+  , testCase "lists static model" testListModels
+  ]
+
+testInlineResponse :: Assertion
+testInlineResponse = do
+  let
+    backend = staticBackend $ StaticConfig
+      { svcStaticResponse = StaticInline "candidate one\ncandidate two"
+      }
+
+  result <- generateFits backend "ignored prompt" "ignored model" Nothing
+  result @?= Right "candidate one\ncandidate two"
+
+testFileResponse :: Assertion
+testFileResponse =
+  withSystemTempDirectory "ollama-holes-static" $ \dir -> do
+    let path = dir </> "candidates.txt"
+
+    T.writeFile path $ T.unlines
+      [ "UserId <$> readMaybe s"
+      , "Just (UserId (read s))"
+      ]
+
+    let
+      backend = staticBackend $ StaticConfig
+        { svcStaticResponse = StaticFile path
+        }
+
+    result <- generateFits backend "ignored prompt" "ignored model" Nothing
+
+    result @?=
+      Right (T.unlines
+        [ "UserId <$> readMaybe s"
+        , "Just (UserId (read s))"
+        ])
+
+testListModels :: Assertion
+testListModels = do
+  let
+    backend = staticBackend $ StaticConfig
+      { svcStaticResponse = StaticInline "x"
+      }
+
+  models <- listModels backend
+  models @?= Just ["static"]

--- a/ollama-holes-plugin/spec/GHC/Plugin/OllamaHoles/Data/Service/Parse/Spec.hs
+++ b/ollama-holes-plugin/spec/GHC/Plugin/OllamaHoles/Data/Service/Parse/Spec.hs
@@ -5,6 +5,7 @@ module GHC.Plugin.OllamaHoles.Data.Service.Parse.Spec
 import Data.Either (isLeft)
 import Data.Functor ((<&>))
 import Data.Text (Text)
+import Data.Text qualified as T
 import Test.Tasty
 import Test.Tasty.HUnit (testCase, assertBool, (@?=))
 import Test.Tasty.QuickCheck qualified as QC
@@ -15,7 +16,13 @@ import Toml.TestHelper
 
 import GHC.Plugin.OllamaHoles.Data.Service
 import GHC.Plugin.OllamaHoles.Backend
-  (OpenAIConfig(..), GeminiConfig(..), OllamaConfig(..), BackendConfig(..))
+  ( OpenAIConfig(..)
+  , GeminiConfig(..)
+  , OllamaConfig(..)
+  , StaticConfig(..)
+  , StaticResponse(..)
+  , BackendConfig(..)
+  )
 
 import GHC.Plugin.OllamaHoles.Data.Service.Types.Gen
 
@@ -49,6 +56,38 @@ tests_tomlServiceName_prop = testGroup "tomlServiceName (prop)"
       QC.forAll genServiceNameText $ \name ->
         Toml.runMatcherIgnoreWarn (tomlServiceName (Toml.Text name))
           QC.=== Right (ServiceName name)
+
+  , QC.testProperty "generated static services with inline response parse" $
+    QC.forAll genServiceNameText $ \name ->
+    QC.forAll genStaticResponseText $ \response ->
+      propTomlParseSuccess tomlService
+        ( "name = '" <> name <> "'\n\
+          \protocol = 'static'\n\
+          \response = '''" <> response <> "'''"
+        , Service
+          { svcName = ServiceName name
+          , svcConfig = SvcStatic $
+              StaticConfig
+                { svcStaticResponse = StaticInline response
+                }
+          }
+        )
+
+  , QC.testProperty "generated static services with response files parse" $
+    QC.forAll genServiceNameText $ \name ->
+    QC.forAll genStaticResponseFileText $ \path ->
+      propTomlParseSuccess tomlService
+        ( "name = '" <> name <> "'\n\
+          \protocol = 'static'\n\
+          \response-file = '" <> path <> "'"
+        , Service
+          { svcName = ServiceName name
+          , svcConfig = SvcStatic $
+              StaticConfig
+                { svcStaticResponse = StaticFile (T.unpack path)
+                }
+          }
+        )
   ]
 
 tests_tomlService_unit :: TestTree
@@ -191,6 +230,38 @@ tests_tomlService_unit_success =
             (GeminiConfig "GEMINI_API_KEY")
         }
     )
+
+  , ( "parses static service with inline response"
+    , "name = 'static-inline'\n\
+        \protocol = 'static'\n\
+        \response = '''\n\
+        \UserId <$> readMaybe s\n\
+        \Just (UserId (read s))\n\
+        \'''"
+    , Service
+        { svcName = ServiceName "static-inline"
+        , svcConfig = SvcStatic $
+            StaticConfig
+              { svcStaticResponse =
+                  StaticInline
+                    "UserId <$> readMaybe s\nJust (UserId (read s))\n"
+              }
+        }
+    )
+
+  , ( "parses static service with response file"
+    , "name = 'static-file'\n\
+        \protocol = 'static'\n\
+        \response-file = 'test/fixtures/userid.candidates'"
+    , Service
+        { svcName = ServiceName "static-file"
+        , svcConfig = SvcStatic $
+            StaticConfig
+              { svcStaticResponse =
+                  StaticFile "test/fixtures/userid.candidates"
+              }
+        }
+    )
   ]
 
 tests_tomlService_unit_failure
@@ -224,5 +295,17 @@ tests_tomlService_unit_failure =
   , ( "rejects Gemini service missing key_name"
     , "name = 'gemini'\n\
         \protocol = 'gemini'"
+    )
+
+  , ( "rejects static service missing response and response-file"
+    , "name = 'static'\n\
+        \protocol = 'static'"
+    )
+
+  , ( "rejects static service with both response and response-file"
+    , "name = 'static'\n\
+        \protocol = 'static'\n\
+        \response = 'Just (UserId 0)'\n\
+        \response-file = 'test/fixtures/userid.candidates'"
     )
   ]

--- a/ollama-holes-plugin/spec/GHC/Plugin/OllamaHoles/Data/Service/Types/Gen.hs
+++ b/ollama-holes-plugin/spec/GHC/Plugin/OllamaHoles/Data/Service/Types/Gen.hs
@@ -5,6 +5,8 @@ module GHC.Plugin.OllamaHoles.Data.Service.Types.Gen
   , genUrlText
   , genTemplateFilePathText
   , genTemplateValueText
+  , genStaticResponseText
+  , genStaticResponseFileText
   ) where
 
 import Data.Text (Text)
@@ -82,4 +84,25 @@ genTemplateValueText =
         rest <- QC.listOf $ QC.elements (['a' .. 'z'] <> ['0' .. '9'] <> "-_")
         pure . T.pack $ first : rest
       )
+    ]
+
+genStaticResponseText :: QC.Gen Text
+genStaticResponseText =
+  T.unlines <$> QC.listOf1 genCandidateLineText
+
+genCandidateLineText :: QC.Gen Text
+genCandidateLineText =
+  QC.elements
+    [ "Just (UserId 0)"
+    , "Just (UserId (read s))"
+    , "UserId <$> readMaybe s"
+    , "UserId <$> Just (length s)"
+    ]
+
+genStaticResponseFileText :: QC.Gen Text
+genStaticResponseFileText =
+  QC.elements
+    [ "test/fixtures/userid.candidates"
+    , "spec/fixtures/static.candidates"
+    , "fixtures/candidates.txt"
     ]

--- a/ollama-holes-plugin/spec/Main.hs
+++ b/ollama-holes-plugin/spec/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import Test.Tasty
+import qualified GHC.Plugin.OllamaHoles.Backend.Static.Spec as BackendStaticSpec
 import qualified GHC.Plugin.OllamaHoles.Candidate.Spec as CandidateSpec
 import qualified GHC.Plugin.OllamaHoles.Candidate.Normalize.Spec as NormalizeSpec
 import qualified GHC.Plugin.OllamaHoles.Candidate.Rewrite.Spec as RewriteSpec
@@ -12,7 +13,8 @@ import qualified GHC.Plugin.OllamaHoles.Data.Spec as DataSpec
 main :: IO ()
 main = defaultMain $
     testGroup "ollama-holes"
-        [ CandidateSpec.tests
+        [ BackendStaticSpec.tests
+        , CandidateSpec.tests
         , NormalizeSpec.tests
         , RewriteSpec.tests
         , CompatSpec.tests

--- a/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Backend.hs
+++ b/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Backend.hs
@@ -3,6 +3,7 @@ module GHC.Plugin.OllamaHoles.Backend
   , module GHC.Plugin.OllamaHoles.Backend.Gemini
   , module GHC.Plugin.OllamaHoles.Backend.Ollama
   , module GHC.Plugin.OllamaHoles.Backend.OpenAI
+  , module GHC.Plugin.OllamaHoles.Backend.Static
   , BackendSlug(..)
   , parseBackendSlug
   , renderBackendSlug
@@ -17,11 +18,13 @@ import GHC.Plugin.OllamaHoles.Backend.Common
 import GHC.Plugin.OllamaHoles.Backend.Gemini
 import GHC.Plugin.OllamaHoles.Backend.Ollama
 import GHC.Plugin.OllamaHoles.Backend.OpenAI
+import GHC.Plugin.OllamaHoles.Backend.Static
 
 data BackendSlug
   = Gemini
   | Ollama
   | OpenAI
+  | Static
   deriving (Eq, Show)
 
 parseBackendSlug :: Text -> Maybe BackendSlug
@@ -29,6 +32,7 @@ parseBackendSlug = \case
   "gemini" -> Just Gemini
   "ollama" -> Just Ollama
   "openai" -> Just OpenAI
+  "static" -> Just Static
   _        -> Nothing
 
 renderBackendSlug :: BackendSlug -> Text
@@ -36,6 +40,7 @@ renderBackendSlug = \case
   Gemini -> "gemini"
   Ollama -> "ollama"
   OpenAI -> "openai"
+  Static -> "static"
 
 
 
@@ -43,6 +48,7 @@ data BackendConfig
   = SvcOllama OllamaConfig
   | SvcOpenAI OpenAIConfig
   | SvcGemini GeminiConfig
+  | SvcStatic StaticConfig
   deriving (Eq, Ord, Show, Generic)
 
 configureBackend :: BackendConfig -> Backend
@@ -50,3 +56,4 @@ configureBackend = \case
   SvcOllama cfg -> ollamaBackend cfg
   SvcOpenAI cfg -> openAICompatibleBackend cfg
   SvcGemini cfg -> geminiBackend cfg
+  SvcStatic cfg -> staticBackend cfg

--- a/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Backend/Static.hs
+++ b/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Backend/Static.hs
@@ -8,10 +8,10 @@ module GHC.Plugin.OllamaHoles.Backend.Static
 
 import GHC.Generics (Generic)
 
+import Control.Exception (try, displayException, IOException)
+import Data.Bifunctor (first)
 import Data.Text (Text)
-import Data.Text qualified as T
 import Data.Text.IO qualified as T
-import Data.Maybe (fromMaybe)
 
 import GHC.Plugin.OllamaHoles.Backend.Common
 
@@ -37,4 +37,5 @@ staticBackend StaticConfig{..} = Backend{..}
           pure $ Right response
 
         StaticFile path ->
-          Right <$> T.readFile path
+          fmap (first (displayException @IOException)) $
+            try (T.readFile path)

--- a/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Backend/Static.hs
+++ b/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Backend/Static.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module GHC.Plugin.OllamaHoles.Backend.Static
+  ( StaticConfig(..)
+  , StaticResponse(..)
+  , staticBackend
+  ) where
+
+import GHC.Generics (Generic)
+
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
+import Data.Maybe (fromMaybe)
+
+import GHC.Plugin.OllamaHoles.Backend.Common
+
+data StaticConfig = StaticConfig
+  { svcStaticResponse :: StaticResponse
+  } deriving (Eq, Ord, Show, Generic)
+
+data StaticResponse
+  = StaticInline Text
+  | StaticFile FilePath
+  deriving (Eq, Ord, Show)
+
+staticBackend :: StaticConfig -> Backend
+staticBackend StaticConfig{..} = Backend{..}
+  where
+    listModels :: IO (Maybe [Text])
+    listModels = pure $ Just ["static"]
+
+    generateFits :: Text -> Text -> Maybe a -> IO (Either String Text)
+    generateFits _prompt _modelName _options =
+      case svcStaticResponse of
+        StaticInline response ->
+          pure $ Right response
+
+        StaticFile path ->
+          Right <$> T.readFile path

--- a/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Data/Service/Parse.hs
+++ b/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Data/Service/Parse.hs
@@ -12,7 +12,13 @@ import Toml.Schema
 import Toml.Schema qualified as Toml
 
 import GHC.Plugin.OllamaHoles.Backend
-  (OpenAIConfig(..), GeminiConfig(..), OllamaConfig(..), BackendConfig(..))
+  ( OpenAIConfig(..)
+  , GeminiConfig(..)
+  , OllamaConfig(..)
+  , StaticConfig(..)
+  , StaticResponse(..)
+  , BackendConfig(..)
+  )
 
 import GHC.Plugin.OllamaHoles.Data.Service.Types
 
@@ -51,3 +57,21 @@ tomlBackendConfigFor = \case
 
   bad ->
     fail ("invalid service protocol: " <> T.unpack bad)
+
+parseStaticResponse :: ParseTable l StaticResponse
+parseStaticResponse = do
+  response     <- optKey "response"
+  responseFile <- optKey "response-file"
+
+  case (response, responseFile) of
+    (Just txt, Nothing) ->
+      pure (StaticInline txt)
+
+    (Nothing, Just path) ->
+      pure (StaticFile path)
+
+    (Nothing, Nothing) ->
+      fail "static service requires either `response` or `response-file`"
+
+    (Just _, Just _) ->
+      fail "static service cannot specify both `response` and `response-file`"

--- a/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Data/Service/Parse.hs
+++ b/ollama-holes-plugin/src/GHC/Plugin/OllamaHoles/Data/Service/Parse.hs
@@ -55,6 +55,10 @@ tomlBackendConfigFor = \case
     <$> (GeminiConfig
       <$> reqKey "key_name")
 
+  "static" -> SvcStatic
+    <$> (StaticConfig
+      <$> parseStaticResponse)
+
   bad ->
     fail ("invalid service protocol: " <> T.unpack bad)
 


### PR DESCRIPTION
Adds a static backend for use in tests, particularly to test type checking for hole fits by mocking the LLM response.